### PR TITLE
fixing arg name etype in format_exception

### DIFF
--- a/src/hypofuzz/hy.py
+++ b/src/hypofuzz/hy.py
@@ -272,7 +272,7 @@ class FuzzProcess:
             filename, lineno, *_ = traceback.extract_tb(tb)[-1]
             data.interesting_origin = (type(e), filename, lineno)
             data.extra_information.traceback = "".join(
-                traceback.format_exception(etype=type(e), value=e, tb=tb)
+                traceback.format_exception(type(e), value=e, tb=tb)
             )
         finally:
             data.extra_information.call_repr = (


### PR DESCRIPTION
arg name `etype` has changed in Python 3.10, use positional arg instead.

Closes #16 