### PR TITLE
Fix missing f-string

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,4 +49,4 @@ You accept and agree to the following terms and conditions for Your present and 
 **Other contributors:**
 <!-- Add yourself to the end of the bulleted list below -->
 
-*None yet.*
+* [Liam DeVoe](https://github.com/tybug)

--- a/src/hypofuzz/hy.py
+++ b/src/hypofuzz/hy.py
@@ -53,7 +53,7 @@ def constant_stack_depth() -> Generator[None, None, None]:
     # to imagine an intentionally-deeply-recursive use of this code.
     assert depth <= 1000, (
         f"Hypothesis would usually add {recursion_limit} to the stack depth of "
-        "{depth} here, but we are already much deeper than expected.  Aborting "
+        f"{depth} here, but we are already much deeper than expected.  Aborting "
         "now, to avoid extending the stack limit in an infinite loop..."
     )
     try:


### PR DESCRIPTION
Noticed in passing; untested.

I've added myself to the authors list not because I think the fix is deserving of it (it's not!), but because you seem relatively serious about the licensing CLA, and I want to respect that.

A sidenote: this repository seems to be using CRLF for line endings — a fact I discovered when git helpfully autoconverted them to LF for me on commit, resulting in an unreadable github diff. It might be nice to do a one-time pass to LF on all files.