### PR TITLE
Migrate dashboard to polling the db

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setuptools.setup(
         "psutil >= 3.0.0",
         "pytest >= 6.0.1",
         "requests >= 2.24.0",
+        "msgpack >= 1.1.0",
     ],
     extras_require={
         "pytrace": [

--- a/src/hypofuzz/interface.py
+++ b/src/hypofuzz/interface.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Iterable, List, Optional, Tuple, get_type_hint
 
 import pytest
 import requests
+from hypothesis import settings
 from hypothesis.stateful import RuleBasedStateMachine, run_state_machine_as_test
 
 if TYPE_CHECKING:
@@ -113,8 +114,7 @@ def _fuzz_several(
     tests = [
         t for t in _get_hypothesis_tests_with_pytest(pytest_args) if t.nodeid in nodeids
     ]
-    if port is not None:
-        for t in tests:
-            t._report_change = partial(_post, port)  # type: ignore
+    for t in tests:
+        settings.default.database.save(b"hypofuzz-test-keys", t.database_key)
 
     fuzz_several(*tests)


### PR DESCRIPTION
#3 

Mostly checking that this is the right path forward, and getting a feel for the architecture of the codebase. `msgpack` isn't a hard dependency, we could easily roll our own b64-json-encoded serialization. (but mspack is right there...)

I've noticed coverage dip when restarting the process, after it replays its covering examples. Possibly our criteria for saving inputs isn't synced with the coveragepy coverage, so replaying doesn't get us fully back there. Or we have an actual bug, not sure.

<img width="1304" alt="image" src="https://github.com/user-attachments/assets/dd738628-8944-4674-ab45-59eb95fea933">

P.S. running `hypothesis fuzz` and having fuzzing *just work* feels so incredibly magical.