### PR TITLE
Allow passing host when starting the dashboard

### DIFF
--- a/src/hypofuzz/entrypoint.py
+++ b/src/hypofuzz/entrypoint.py
@@ -31,6 +31,13 @@ import psutil
     help="serve a live dashboard page without launching associated fuzzing processes",
 )
 @click.option(
+    "--host",
+    type=str,
+    default="localhost",
+    metavar="HOST",
+    help="Optional host for the dashboard",
+)
+@click.option(
     "--port",
     type=click.IntRange(1, 65535),
     default=9999,
@@ -51,6 +58,7 @@ def fuzz(
     numprocesses: int,
     dashboard: bool,
     dashboard_only: bool,
+    host: Optional[str],
     port: Optional[int],
     unsafe: bool,
     pytest_args: tuple[str, ...],
@@ -69,7 +77,7 @@ def fuzz(
 
         dash_proc = Process(
             target=start_dashboard_process,
-            kwargs={"port": port, "pytest_args": pytest_args},
+            kwargs={"host": host, "port": port, "pytest_args": pytest_args},
         )
         dash_proc.start()
 


### PR DESCRIPTION
The reason for this PR is that I am often running the hypofuzz server in my homelab now and in order to access the dashboard from my workstation, I always need to apply this patch after installation :see_no_evil: Would it be acceptable to actually incorporate this as a cli argument? I intentionally kept the changes minimal, without adding IPv4/IPv6/FQDN validation, but if you find it useful, I can also add a custom `click` type instead of the plain `str`.

```diff
@@ -344,7 +344,7 @@ def patch_summary() -> flask.Response:
 
 
 def start_dashboard_process(
-    port: int, *, pytest_args: list, host: str = "localhost", debug: bool = False
+    port: int, *, pytest_args: list, host: str = "0.0.0.0", debug: bool = False
 ) -> None:
     global PYTEST_ARGS
     PYTEST_ARGS = pytest_args
```