### PR TITLE
Implement Chao lower bound on number of branches

### DIFF
--- a/src/hypofuzz/corpus.py
+++ b/src/hypofuzz/corpus.py
@@ -135,6 +135,18 @@ class Pool:
     def _fuzz_key(self) -> bytes:
         return self._key + b".fuzz"
 
+    @property
+    def singletons(self) -> int:
+        # Because _every_ arc hit is counted at least once, singletons are those arcs that have that base hit,
+        # and then _one_ more on top of it.
+        singletons = [item for item in self.overall_arc_counts.values() if 2 == item]
+        return len(singletons)
+
+    @property
+    def doubletons(self) -> int:
+        doubletons = [item for item in self.overall_arc_counts.values() if 3 == item]
+        return len(doubletons)
+
     def add(self, result: ConjectureResult, source: HowGenerated) -> Optional[bool]:
         """Update the corpus with the result of running a test.
 

--- a/src/hypofuzz/corpus.py
+++ b/src/hypofuzz/corpus.py
@@ -86,6 +86,8 @@ class Pool:
         self.covering_buffers: dict[Arc, bytes] = {}
         # How many times have we seen each arc since discovering our latest arc?
         self.arc_counts: Counter[Arc] = Counter()
+        # How many times have we seen each arc since start of run?
+        self.overall_arc_counts: Counter[Arc] = Counter()
 
         # And various internal attributes and metadata
         self.interesting_examples: dict[
@@ -214,11 +216,13 @@ class Pool:
         # have a different distribution with a new seed pool.
         if branches.issubset(self.arc_counts):
             self.arc_counts.update(branches)
+            self.overall_arc_counts.update(branches)
         else:
             # Reset our seen arc counts.  This is essential because changing our
             # seed pool alters the probability of seeing each arc in future.
             # For details see AFL-fast, esp. the markov-chain trick.
             self.arc_counts = Counter(branches.union(self.arc_counts))
+            self.overall_arc_counts.update(branches)
 
             # Save this buffer as our minimal-known covering example for each new arc.
             if result.buffer not in self.results:

--- a/src/hypofuzz/dashboard.py
+++ b/src/hypofuzz/dashboard.py
@@ -24,7 +24,7 @@ LAST_UPDATE: dict = {}
 
 PYTEST_ARGS = None
 
-headings = ["nodeid", "elapsed time", "ninputs", "since new cov", "branches", "note"]
+headings = ["nodeid", "elapsed time", "ninputs", "since new cov", "branches", "est. branches", "note"]
 app = flask.Flask(__name__, static_folder=os.path.abspath("pycrunch-recordings"))
 
 try:

--- a/src/hypofuzz/hy.py
+++ b/src/hypofuzz/hy.py
@@ -379,6 +379,7 @@ class FuzzProcess:
             "worker": where_am_i(),
             "ninputs": self.ninputs,
             "branches": len(self.pool.arc_counts),
+            "est. branches": "",
             "since new cov": self.since_new_cov,
             "loaded_from_db": len(self.pool._loaded_from_database),
             "status_counts": dict(self.status_counts),

--- a/src/hypofuzz/hy.py
+++ b/src/hypofuzz/hy.py
@@ -399,6 +399,13 @@ class FuzzProcess:
                 ls for _, ls in self.pool.interesting_examples.values()
             ]
             del report["since new cov"]
+
+        if self.ninputs >= 10 and "" == report["note"]:
+            singletons = self.pool.singletons
+            doubletons = self.pool.doubletons
+            offset = singletons * (singletons-1) / 2 if 0 == doubletons else singletons * singletons / (2 * doubletons)
+            offset = int(offset) + 1
+            report["est. branches"] = report["branches"] + offset
         return report
 
     @property


### PR DESCRIPTION
As mentioned in https://github.com/Zac-HD/hypofuzz/issues/11#issuecomment-2537950837 , add singleton and doubleton counting to `Pool`.
After that, calculate the basic Chao bound on number of branches after the later of 10 inputs into a run, or previously-saved examples have been replayed.