### PR TITLE
Use `sys.monitoring` and optimize db usage

### DIFF
--- a/deps/check.txt
+++ b/deps/check.txt
@@ -4,14 +4,14 @@
 #
 #    pip-compile --annotation-style=line --output-file=deps/check.txt deps/check.in
 #
-attrs==24.2.0             # via -r deps/check.in
+attrs==24.3.0             # via -r deps/check.in
 black==24.10.0            # via shed
-click==8.1.7              # via black
+click==8.1.8              # via black
 com2ann==0.3.0            # via shed
 flake8==7.1.1             # via pep8-naming
 libcst==1.5.1             # via shed
 mccabe==0.7.0             # via flake8
-mypy==1.13.0              # via -r deps/check.in
+mypy==1.14.1              # via -r deps/check.in
 mypy-extensions==1.0.0    # via black, mypy
 packaging==24.2           # via black
 pathspec==0.12.1          # via black
@@ -19,12 +19,12 @@ pep8-naming==0.14.1       # via -r deps/check.in
 platformdirs==4.3.6       # via black
 pycodestyle==2.12.1       # via flake8
 pyflakes==3.2.0           # via flake8
-pyupgrade==3.19.0         # via shed
+pyupgrade==3.19.1         # via shed
 pyyaml==6.0.2             # via libcst
-ruff==0.8.2               # via -r deps/check.in, shed
+ruff==0.9.0               # via -r deps/check.in, shed
 shed==2024.10.1           # via -r deps/check.in
 tokenize-rt==6.1.0        # via pyupgrade
 tomli==2.2.1              # via black, mypy
 types-requests==2.32.0.20241016  # via -r deps/check.in
 typing-extensions==4.12.2  # via black, mypy
-urllib3==2.2.3            # via types-requests
+urllib3==2.3.0            # via types-requests

--- a/deps/docs.txt
+++ b/deps/docs.txt
@@ -5,14 +5,14 @@
 #    pip-compile --annotation-style=line --output-file=deps/docs.txt deps/docs.in setup.py
 #
 alabaster==1.0.0          # via sphinx
-attrs==24.2.0             # via hypothesis
+attrs==24.3.0             # via hypothesis
 babel==2.16.0             # via sphinx
 black==24.10.0            # via hypofuzz (setup.py), hypothesis
 blinker==1.9.0            # via flask
-certifi==2024.8.30        # via requests
-charset-normalizer==3.4.0  # via requests
-click==8.1.7              # via black, flask, hypothesis
-coverage==7.6.8           # via hypofuzz (setup.py)
+certifi==2024.12.14       # via requests
+charset-normalizer==3.4.1  # via requests
+click==8.1.8              # via black, flask, hypothesis
+coverage==7.6.10          # via hypofuzz (setup.py)
 dash==2.18.2              # via hypofuzz (setup.py)
 dash-core-components==2.0.0  # via dash
 dash-html-components==2.0.0  # via dash
@@ -20,13 +20,13 @@ dash-table==5.0.0         # via dash
 docutils==0.21.2          # via myst-parser, pybtex-docutils, sphinx, sphinx-rtd-theme, sphinxcontrib-bibtex
 exceptiongroup==1.2.2     # via hypothesis, pytest
 flask==3.0.3              # via dash
-hypothesis[cli]==6.121.0  # via hypofuzz (setup.py)
+hypothesis[cli]==6.123.13  # via hypofuzz (setup.py)
 idna==3.10                # via requests
 imagesize==1.4.1          # via sphinx
 importlib-metadata==8.5.0  # via dash
 iniconfig==2.0.0          # via pytest
 itsdangerous==2.2.0       # via flask
-jinja2==3.1.4             # via flask, myst-parser, sphinx
+jinja2==3.1.5             # via flask, myst-parser, sphinx
 latexcodec==3.0.0         # via pybtex
 libcst==1.5.1             # via hypofuzz (setup.py)
 markdown-it-py==3.0.0     # via mdit-py-plugins, myst-parser, rich
@@ -36,25 +36,25 @@ mdurl==0.1.2              # via markdown-it-py
 mypy-extensions==1.0.0    # via black
 myst-parser==4.0.0        # via -r deps/docs.in
 nest-asyncio==1.6.0       # via dash
-numpy==2.1.3              # via pandas
+numpy==2.2.1              # via pandas
 packaging==24.2           # via black, plotly, pytest, sphinx
 pandas==2.2.3             # via hypofuzz (setup.py)
 pathspec==0.12.1          # via black
 platformdirs==4.3.6       # via black
 plotly==5.24.1            # via dash
 pluggy==1.5.0             # via pytest
-psutil==6.1.0             # via hypofuzz (setup.py)
+psutil==6.1.1             # via hypofuzz (setup.py)
 pybtex==0.24.0            # via pybtex-docutils, sphinxcontrib-bibtex
 pybtex-docutils==1.0.3    # via sphinxcontrib-bibtex
-pygments==2.18.0          # via rich, sphinx
-pytest==8.3.3             # via hypofuzz (setup.py)
+pygments==2.19.1          # via rich, sphinx
+pytest==8.3.4             # via hypofuzz (setup.py)
 python-dateutil==2.9.0.post0  # via pandas
 pytz==2024.2              # via pandas
 pyyaml==6.0.2             # via libcst, myst-parser, pybtex
 requests==2.32.3          # via dash, hypofuzz (setup.py), sphinx
 retrying==1.3.4           # via dash
 rich==13.9.4              # via hypothesis
-six==1.16.0               # via pybtex, python-dateutil, retrying
+six==1.17.0               # via pybtex, python-dateutil, retrying
 snowballstemmer==2.2.0    # via sphinx
 sortedcontainers==2.4.0   # via hypothesis
 sphinx==8.1.3             # via -r deps/docs.in, myst-parser, sphinx-rtd-theme, sphinxcontrib-bibtex, sphinxcontrib-jquery, sphinxcontrib-programoutput
@@ -65,14 +65,14 @@ sphinxcontrib-devhelp==2.0.0  # via sphinx
 sphinxcontrib-htmlhelp==2.1.0  # via sphinx
 sphinxcontrib-jquery==4.1  # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1  # via sphinx
-sphinxcontrib-programoutput==0.17  # via -r deps/docs.in
+sphinxcontrib-programoutput==0.18  # via -r deps/docs.in
 sphinxcontrib-qthelp==2.0.0  # via sphinx
 sphinxcontrib-serializinghtml==2.0.0  # via sphinx
 tenacity==9.0.0           # via plotly
 tomli==2.2.1              # via black, pytest, sphinx
 typing-extensions==4.12.2  # via black, dash, rich
 tzdata==2024.2            # via pandas
-urllib3==2.2.3            # via requests
+urllib3==2.3.0            # via requests
 werkzeug==3.0.6           # via dash, flask
 zipp==3.21.0              # via importlib-metadata
 

--- a/deps/test-old.txt
+++ b/deps/test-old.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile --annotation-style=line --output-file=deps/test-old.txt deps/test-old.in setup.py
 #
-attrs==24.2.0             # via hypothesis
+attrs==24.3.0             # via hypothesis
 black==24.10.0            # via hypofuzz (setup.py), hypothesis
 blinker==1.9.0            # via flask
-certifi==2024.8.30        # via requests
-charset-normalizer==3.4.0  # via requests
-click==8.1.7              # via black, flask, hypothesis
-coverage[toml]==7.6.8     # via hypofuzz (setup.py), pytest-cov
+certifi==2024.12.14       # via requests
+charset-normalizer==3.4.1  # via requests
+click==8.1.8              # via black, flask, hypothesis
+coverage[toml]==7.6.10    # via hypofuzz (setup.py), pytest-cov
 dash==2.18.2              # via hypofuzz (setup.py)
 dash-core-components==2.0.0  # via dash
 dash-html-components==2.0.0  # via dash
@@ -18,12 +18,12 @@ dash-table==5.0.0         # via dash
 exceptiongroup==1.2.2     # via hypothesis, pytest
 execnet==2.1.1            # via pytest-xdist
 flask==3.0.3              # via dash
-hypothesis[cli]==6.121.0  # via hypofuzz (setup.py)
+hypothesis[cli]==6.123.13  # via hypofuzz (setup.py)
 idna==3.10                # via requests
 importlib-metadata==8.5.0  # via dash
 iniconfig==2.0.0          # via pytest
 itsdangerous==2.2.0       # via flask
-jinja2==3.1.4             # via flask
+jinja2==3.1.5             # via flask
 libcst==1.5.1             # via hypofuzz (setup.py)
 markdown-it-py==3.0.0     # via rich
 markupsafe==3.0.2         # via jinja2, werkzeug
@@ -37,9 +37,9 @@ pathspec==0.12.1          # via black
 platformdirs==4.3.6       # via black
 plotly==5.24.1            # via dash
 pluggy==1.5.0             # via pytest
-psutil==6.1.0             # via hypofuzz (setup.py)
+psutil==6.1.1             # via hypofuzz (setup.py)
 pyarrow==18.1.0           # via -r deps/test.in
-pygments==2.18.0          # via rich
+pygments==2.19.1          # via rich
 pytest==7.4.4             # via -r deps/test.in, -r deps/test-old.in, hypofuzz (setup.py), pytest-cov, pytest-xdist
 pytest-cov==6.0.0         # via -r deps/test.in
 pytest-xdist==3.6.1       # via -r deps/test.in
@@ -49,13 +49,13 @@ pyyaml==6.0.2             # via libcst
 requests==2.32.3          # via dash, hypofuzz (setup.py)
 retrying==1.3.4           # via dash
 rich==13.9.4              # via hypothesis
-six==1.16.0               # via python-dateutil, retrying
+six==1.17.0               # via python-dateutil, retrying
 sortedcontainers==2.4.0   # via hypothesis
 tenacity==9.0.0           # via plotly
 tomli==2.2.1              # via black, coverage, pytest
 typing-extensions==4.12.2  # via black, dash, rich
 tzdata==2024.2            # via pandas
-urllib3==2.2.3            # via requests
+urllib3==2.3.0            # via requests
 werkzeug==3.0.6           # via dash, flask
 zipp==3.21.0              # via importlib-metadata
 

--- a/deps/test.txt
+++ b/deps/test.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile --annotation-style=line --output-file=deps/test.txt deps/test.in setup.py
 #
-attrs==24.2.0             # via hypothesis
+attrs==24.3.0             # via hypothesis
 black==24.10.0            # via hypofuzz (setup.py), hypothesis
 blinker==1.9.0            # via flask
-certifi==2024.8.30        # via requests
-charset-normalizer==3.4.0  # via requests
-click==8.1.7              # via black, flask, hypothesis
-coverage[toml]==7.6.9     # via hypofuzz (setup.py), pytest-cov
+certifi==2024.12.14       # via requests
+charset-normalizer==3.4.1  # via requests
+click==8.1.8              # via black, flask, hypothesis
+coverage[toml]==7.6.10    # via hypofuzz (setup.py), pytest-cov
 dash==2.18.2              # via hypofuzz (setup.py)
 dash-core-components==2.0.0  # via dash
 dash-html-components==2.0.0  # via dash
@@ -18,12 +18,12 @@ dash-table==5.0.0         # via dash
 exceptiongroup==1.2.2     # via hypothesis, pytest
 execnet==2.1.1            # via pytest-xdist
 flask==3.0.3              # via dash
-hypothesis[cli]==6.122.3  # via hypofuzz (setup.py)
+hypothesis[cli]==6.123.13  # via hypofuzz (setup.py)
 idna==3.10                # via requests
 importlib-metadata==8.5.0  # via dash
 iniconfig==2.0.0          # via pytest
 itsdangerous==2.2.0       # via flask
-jinja2==3.1.4             # via flask
+jinja2==3.1.5             # via flask
 libcst==1.5.1             # via hypofuzz (setup.py)
 markdown-it-py==3.0.0     # via rich
 markupsafe==3.0.2         # via jinja2, werkzeug
@@ -37,9 +37,9 @@ pathspec==0.12.1          # via black
 platformdirs==4.3.6       # via black
 plotly==5.24.1            # via dash
 pluggy==1.5.0             # via pytest
-psutil==6.1.0             # via hypofuzz (setup.py)
+psutil==6.1.1             # via hypofuzz (setup.py)
 pyarrow==18.1.0           # via -r deps/test.in
-pygments==2.18.0          # via rich
+pygments==2.19.1          # via rich
 pytest==8.3.4             # via -r deps/test.in, hypofuzz (setup.py), pytest-cov, pytest-xdist
 pytest-cov==6.0.0         # via -r deps/test.in
 pytest-xdist==3.6.1       # via -r deps/test.in
@@ -55,7 +55,7 @@ tenacity==9.0.0           # via plotly
 tomli==2.2.1              # via black, coverage, pytest
 typing-extensions==4.12.2  # via black, dash, rich
 tzdata==2024.2            # via pandas
-urllib3==2.2.3            # via requests
+urllib3==2.3.0            # via requests
 werkzeug==3.0.6           # via dash, flask
 zipp==3.21.0              # via importlib-metadata
 

--- a/docs-src/changelog.md
+++ b/docs-src/changelog.md
@@ -2,6 +2,12 @@
 HypoFuzz uses [calendar-based versioning](https://calver.org/), with a
 `YY-MM-patch` format.
 
+## 25.01.2
+
+Hypofuzz now uses [`sys.monitoring`](https://docs.python.org/3/library/sys.monitoring.html) for coverage instrumentation on python 3.12+, resulting in considerable speedups for recent python versions.
+
+Also optimized database disk usage.
+
 ## 25.01.1
 
 The dashboard now respects the current setting profile's database when loading fuzzing progress.

--- a/docs-src/changelog.md
+++ b/docs-src/changelog.md
@@ -8,6 +8,10 @@ Hypofuzz now uses [`sys.monitoring`](https://docs.python.org/3/library/sys.monit
 
 Also optimized database disk usage.
 
+
+Requires [Hypothesis 6.123.12](https://hypothesis.readthedocs.io/en/latest/changes.html#v6.123.12)
+or newer, for a race condition fix which Hypofuzz is liable to hit.
+
 ## 25.01.1
 
 The dashboard now respects the current setting profile's database when loading fuzzing progress.

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setuptools.setup(
         "black >= 23.3.0",
         "coverage >= 5.2.1",
         "dash >= 2.0.0",
-        "hypothesis[cli] >= 6.121.0",
+        "hypothesis[cli] >= 6.123.12",
         "libcst >= 1.0.0",
         "pandas >= 1.0.0",
         "psutil >= 3.0.0",

--- a/src/hypofuzz/__init__.py
+++ b/src/hypofuzz/__init__.py
@@ -1,4 +1,4 @@
 """Adaptive fuzzing for property-based tests using Hypothesis."""
 
-__version__ = "25.01.1"
+__version__ = "25.01.2"
 __all__: list = []

--- a/src/hypofuzz/cov.py
+++ b/src/hypofuzz/cov.py
@@ -66,7 +66,7 @@ is_hypofuzz_file = belongs_to(hypofuzz)
 
 
 @cache
-def should_trace(fname):
+def should_trace(fname: str) -> bool:
     return not (is_hypothesis_file(fname) or is_hypofuzz_file(fname))
 
 

--- a/src/hypofuzz/cov.py
+++ b/src/hypofuzz/cov.py
@@ -1,11 +1,16 @@
 """Adaptive fuzzing for property-based tests using Hypothesis."""
 
 import sys
+import types
+from functools import cache
 from typing import Any, Optional
 
 import attr
 import coverage
-from hypothesis.internal.escalation import is_hypothesis_file
+import hypothesis
+from hypothesis.internal.escalation import belongs_to
+
+import hypofuzz
 
 # The upstream notion of an arc is (int, int) with an implicit filename,
 # but HypoFuzz uses an explicit filename as part of the arc.
@@ -56,74 +61,74 @@ def get_possible_branches(cov: coverage.CoverageData, fname: str) -> frozenset[A
         return _POSSIBLE_ARCS[fname]
 
 
-class CollectionContext:
-    """Collect coverage data as a context manager.
-
-    The context manager can be reused; each use updates the ``.branches``
-    attribute which will be reset on next use.
-
-    TODO: excluding Hypothesis (and fuzz) files from tracing as well
-            as results would be a small performance upgrade.
-    """
-
-    def __init__(self, cov: coverage.CoverageData = None) -> None:
-        self.cov = cov or get_coverage_instance()
-        self.branches: set[Arc] = set()
-
-    def __enter__(self) -> None:
-        self.branches = set()
-        self.cov.erase()
-        self.cov.start()
-
-    def __exit__(self, _type: Exception, _value: object, _traceback: object) -> None:
-        # The `stop()` line shows up as uncovered because we are always running under
-        # our *internal* coverage, not *selftest* coverage, here and we don't yet have
-        # a way to pass the data back out without breaking pytest-cov's reporting.
-        self.cov.stop()  # pragma: no cover
-        self.cov.save()
-        for f in self.cov._data.measured_files():
-            if not is_hypothesis_file(f):
-                self.branches.update(
-                    Arc.make(f, src, dst) for src, dst in self.cov._data.branches(f)
-                )
-                # For later: we may want to generalise our notion of an arc to include
-                # coverage contexts, for easy Nezha-style differential fuzzing.
-                # See `CoverageData.contexts_by_lineno()` for this.
-
-        # If coverage was already running, e.g. for HypoFuzz' self-tests,
-        # update that previous instance with the data we just collected.
-        # *except* that this pollutes the report with way to much extra data...
-        # This would also need to handle the not-under-coverage case, for both
-        # correctness and performance.
-        # coverage.Coverage.current()._data.update(self.cov._data)
+is_hypothesis_file = belongs_to(hypothesis)
+is_hypofuzz_file = belongs_to(hypofuzz)
 
 
+@cache
+def should_trace(fname):
+    return not (is_hypothesis_file(fname) or is_hypofuzz_file(fname))
+
+
+# use 3.12's sys.monitoring where possible, and sys.settrace otherwise.
 class CustomCollectionContext:
     """Collect coverage data as a context manager.
 
     The context manager can be reused; each use updates the ``.branches``
     attribute which will be reset on next use.
-
-    TODO: excluding Hypothesis (and fuzz) files from tracing as well
-            as results would be a small performance upgrade.
     """
 
+    # tool_id = 1 is designated for coverage, but we intentionally choose a
+    # non-reserved tool id so we can co-exist with coverage tools.
+    tool_id: int = 3
+    tool_name: str = "hypofuzz"
     last: Optional[tuple]
 
-    def trace(self, frame: Any, event: Any, arg: Any) -> Any:
+    if sys.version_info[:2] >= (3, 12):
+        events = {
+            sys.monitoring.events.LINE: "trace_line",
+        }
+
+    def trace_pre_312(self, frame: Any, event: Any, arg: Any) -> Any:
         if event == "line":
             fname = frame.f_code.co_filename
-            if not is_hypothesis_file(fname):
+            if should_trace(fname):
                 this = (fname, frame.f_lineno)
                 self.branches.add((self.last, this))
                 self.last = this
-        return self.trace
+        return self.trace_pre_312
+
+    def trace_line(self, code: types.CodeType, line_number: int) -> None:
+        fname = code.co_filename
+        if not should_trace(fname):
+            # this function is only called on 3.12+, but we want to avoid an
+            # assertion to that effect for performance.
+            return sys.monitoring.DISABLE  # type: ignore
+
+        this = (fname, line_number)
+        self.branches.add((self.last, this))
+        self.last = this
 
     def __enter__(self) -> None:
         self.last = None
         self.branches: set[tuple] = set()
-        self.prev_trace = sys.gettrace()
-        sys.settrace(self.trace)
+
+        if sys.version_info[:2] < (3, 12):
+            self.prev_trace = sys.gettrace()
+            sys.settrace(self.trace_pre_312)
+            return
+
+        sys.monitoring.use_tool_id(self.tool_id, self.tool_name)
+        for event, callback_name in self.events.items():
+            sys.monitoring.set_events(self.tool_id, event)
+            callback = getattr(self, callback_name)
+            sys.monitoring.register_callback(self.tool_id, event, callback)
 
     def __exit__(self, _type: Exception, _value: object, _traceback: object) -> None:
-        sys.settrace(self.prev_trace)
+        if sys.version_info[:2] < (3, 12):
+            sys.settrace(self.prev_trace)
+            return
+
+        sys.monitoring.free_tool_id(self.tool_id)
+        for event in self.events:
+            sys.monitoring.register_callback(self.tool_id, event, None)

--- a/src/hypofuzz/database.py
+++ b/src/hypofuzz/database.py
@@ -33,7 +33,7 @@ class HypofuzzDatabase:
         self._db.delete(metadata_key(key), bytes(json.dumps(report), "ascii"))
 
     def fetch_metadata(self, key: bytes) -> Iterable[Report]:
-        return map(json.loads, self._db.fetch(metadata_key(key)))
+        return [json.loads(e) for e in self._db.fetch(metadata_key(key))]
 
 
 # cache to make the db a singleton. We defer creation until first-usage to ensure

--- a/src/hypofuzz/hy.py
+++ b/src/hypofuzz/hy.py
@@ -349,13 +349,9 @@ class FuzzProcess:
         db = get_db()
         db.save_metadata(self.database_key, report)
 
-        # To avoid large db sizes, we only store some fields for the latest report.
-        # Additionally, if the previous report doesn't add anything relative to
-        # this one, we drop the previous report entirely.
-        #
-        # We first unconditionally drop the previous report. If we determine we
-        # should keep it, we then re-add its reduced version, with the fields we
-        # only keep for the latest report removed.
+        # Having written the latest report, we can avoid bloating the database
+        # by dropping the previous report, and re-adding a trimmed version if
+        # it differs from the latest in more than just runtime.
         # TODO proper typing for Report and ReportReduced
         db.delete_metadata(self.database_key, self._last_report)
         if self._last_report and (

--- a/src/hypofuzz/hy.py
+++ b/src/hypofuzz/hy.py
@@ -356,6 +356,7 @@ class FuzzProcess:
         # We first unconditionally drop the previous report. If we determine we
         # should keep it, we then re-add its reduced version, with the fields we
         # only keep for the latest report removed.
+        # TODO proper typing for Report and ReportReduced
         db.delete_metadata(self.database_key, self._last_report)
         if self._last_report and (
             self._last_report["branches"] != report["branches"]

--- a/src/hypofuzz/hy.py
+++ b/src/hypofuzz/hy.py
@@ -353,7 +353,9 @@ class FuzzProcess:
         # by dropping the previous report, and re-adding a trimmed version if
         # it differs from the latest in more than just runtime.
         # TODO proper typing for Report and ReportReduced
-        db.delete_metadata(self.database_key, self._last_report)
+        if self._last_report:
+            db.delete_metadata(self.database_key, self._last_report)
+
         if self._last_report and (
             self._last_report["branches"] != report["branches"]
             or self._last_report["note"] != report["note"]

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,11 +1,11 @@
 import re
 import shutil
 import subprocess
+import tempfile
 import time
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Optional
-import tempfile
 
 import attr
 import requests
@@ -29,7 +29,7 @@ def wait_for(condition, *, timeout, interval):
             return
         time.sleep(interval)
     raise Exception(
-        f"timing out after waiting {timeout}s for condition"
+        f"timing out after waiting {timeout}s for condition "
         f"{get_pretty_function_description(condition)}"
     )
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -18,11 +18,13 @@ def test_database_only_stores_full_entries_in_latest():
         assert len(keys) == 1
         key = list(keys)[0]
 
-        for i in range(10):
-            # wait for db entries to roll in - it's ok if they bunch up and cause
-            # some iterations to check the same thing.
+        previous_size = 0
+        for _ in range(10):
+            # wait for new db entries to roll in
             wait_for(
-                lambda: len(list(db.fetch_metadata(key))) > i, timeout=10, interval=0.05
+                lambda: len(list(db.fetch_metadata(key))) > previous_size,
+                timeout=10,
+                interval=0.05,
             )
             metadata = sorted(db.fetch_metadata(key), key=lambda d: d["elapsed_time"])
             assert "seed_pool" in metadata[-1], metadata
@@ -32,3 +34,5 @@ def test_database_only_stores_full_entries_in_latest():
             for report in metadata[:-2]:
                 assert "nodeid" in report
                 assert "seed_pool" not in report
+
+            previous_size = len(metadata)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,7 +1,7 @@
+from common import fuzz, wait_for, write_basic_test_code
 from hypothesis.database import DirectoryBasedExampleDatabase
 
 from hypofuzz.database import HypofuzzDatabase
-from common import fuzz, wait_for, write_basic_test_code
 
 
 def test_database_only_stores_full_entries_in_latest():
@@ -19,11 +19,14 @@ def test_database_only_stores_full_entries_in_latest():
         key = list(keys)[0]
 
         previous_size = 0
-        for _ in range(10):
+        # we're fuzzing actual json.loads here on relatively slow ci machines,
+        # so keep the iteration count relatively low to avoid the fuzz process
+        # taking longer than our timeout to find new coverage.
+        for _ in range(5):
             # wait for new db entries to roll in
             wait_for(
                 lambda: len(list(db.fetch_metadata(key))) > previous_size,
-                timeout=10,
+                timeout=15,
                 interval=0.05,
             )
             metadata = sorted(db.fetch_metadata(key), key=lambda d: d["elapsed_time"])

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,34 @@
+from hypothesis.database import DirectoryBasedExampleDatabase
+
+from hypofuzz.database import HypofuzzDatabase
+from common import fuzz, wait_for, write_basic_test_code
+
+
+def test_database_only_stores_full_entries_in_latest():
+    test_dir, db_dir = write_basic_test_code()
+    db = HypofuzzDatabase(DirectoryBasedExampleDatabase(db_dir))
+    assert not list(db.fetch(b"hypofuzz-test-keys"))
+
+    with fuzz(test_dir=test_dir):
+        wait_for(
+            lambda: list(db.fetch(b"hypofuzz-test-keys")), timeout=10, interval=0.1
+        )
+        keys = list(db.fetch(b"hypofuzz-test-keys"))
+        # we're only working with a single test
+        assert len(keys) == 1
+        key = list(keys)[0]
+
+        for i in range(10):
+            # wait for db entries to roll in - it's ok if they bunch up and cause
+            # some iterations to check the same thing.
+            wait_for(
+                lambda: len(list(db.fetch_metadata(key))) > i, timeout=10, interval=0.05
+            )
+            metadata = sorted(db.fetch_metadata(key), key=lambda d: d["elapsed_time"])
+            assert "seed_pool" in metadata[-1], metadata
+            # allow a leeway of one report due to race conditions: we might save the
+            # latest full report before paring the previously-latest (now second)
+            # report down to reduced.
+            for report in metadata[:-2]:
+                assert "nodeid" in report
+                assert "seed_pool" not in report

--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,6 @@ ignore_missing_imports = True
 implicit_reexport = False
 warn_no_return = True
 warn_return_any = True
-warn_unreachable = True
 warn_unused_ignores = True
 warn_unused_configs = True
 warn_redundant_casts = True


### PR DESCRIPTION
For the database, it's mostly `seed_pool` which can be very large, and we only need that attribute for the latest entry. (now that I write this,  we may want to stick attrs like this into a separate key `.metadata-latest` instead so we don't have to do the reduce-old-reports song and dance).

I'd like to write lots of tests for coverage - eventually. Needs its own entire pull. But if you see a missing cov instrumention test which blocks this pull, let me know.