### PR TITLE
Support autouse fixtures that request another fixture

### DIFF
--- a/docs-src/changelog.md
+++ b/docs-src/changelog.md
@@ -2,6 +2,10 @@
 HypoFuzz uses [calendar-based versioning](https://calver.org/), with a
 `YY-MM-patch` format.
 
+## 25.01.3
+
+Support collecting tests with a pytest autouse fixture that itself requests a non-autouse fixture.
+
 ## 25.01.2
 
 Hypofuzz now uses [`sys.monitoring`](https://docs.python.org/3/library/sys.monitoring.html) for coverage instrumentation on python 3.12+, resulting in considerable speedups for recent python versions.

--- a/src/hypofuzz/__init__.py
+++ b/src/hypofuzz/__init__.py
@@ -1,4 +1,4 @@
 """Adaptive fuzzing for property-based tests using Hypothesis."""
 
-__version__ = "25.01.2"
+__version__ = "25.01.3"
 __all__: list = []

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,37 +1,70 @@
 """Tests for the hypofuzz library."""
 
+import inspect
+import tempfile
+from pathlib import Path
+
 from hypofuzz import interface
-
-TEST_CODE = """
-import pytest
-from hypothesis import given, settings, strategies as st
-
-@pytest.fixture(autouse=True)
-def fixture():
-    pass
-
-@given(st.none())
-def test_autouse(x):
-    pass
+from hypofuzz.hy import FuzzProcess
 
 
-@pytest.fixture()
-def other_fixture():
-    pass
-
-@given(st.none())
-def test_with_fixture(x, other_fixture):
-    pass
-"""
-
-
-def test_collects_despite_autouse_fixtures(tmp_path):
-    test_fname = tmp_path / "test_demo.py"
-    test_fname.write_text(TEST_CODE, encoding="utf-8")
-    try:
-        fps = interface._get_hypothesis_tests_with_pytest(
-            ["-p", "no:dash", str(test_fname)]
+def collect(code: str) -> list[FuzzProcess]:
+    code = (
+        inspect.cleandoc(
+            """
+            import pytest
+            from hypothesis import given, strategies as st
+            """
         )
-    except SystemExit as err:
-        raise AssertionError from err
-    assert len(fps) == 1
+        + "\n"
+        + inspect.cleandoc(code)
+    )
+    p = Path(tempfile.mkstemp(prefix="test_", suffix=".py")[1])
+    p.write_text(code)
+    fps = interface._get_hypothesis_tests_with_pytest([str(p), "-p", "no:dash"])
+    p.unlink()
+    return fps
+
+
+def collect_names(code: str) -> set[str]:
+    return {fp._test_fn.__name__ for fp in collect(code)}
+
+
+def test_collects_autouse_fixtures():
+    code = """
+        @pytest.fixture(autouse=True)
+        def fixture(): ...
+
+        @given(st.none())
+        def test_autouse(x): ...
+        """
+    assert collect_names(code) == {"test_autouse"}
+
+
+def test_collects_autouse_that_uses_fixture():
+    code = """
+    @pytest.fixture(autouse=True)
+    def myfixture(monkeypatch): ...
+
+    @given(st.none())
+    def test_autouse(): ...
+    """
+    assert collect_names(code) == {"test_autouse"}
+
+
+def test_does_not_collect_explicit_fixture_even_if_autouse():
+    # if the autouse fixture *wasnt* here, this test would not be collected
+    # because of the explicit fixture. Make sure this is still true in light
+    # of our special logic for autouse fixtures.
+    code = """
+    @pytest.fixture()
+    def myfixture(): ...
+
+    @pytest.fixture(autouse=True)
+    def myautousefixture(myfixture): ...
+
+    @given(st.none())
+    def test_autouse(myfixture, x): ...
+    """
+
+    assert collect_names(code) == set()


### PR DESCRIPTION
This happens when fuzzing Hypothesis itself, as our `_consistently_increment_time` autouse fixture uses the `monkeypatch` fixture. See also https://github.com/Zac-HD/hypofuzz/issues/38#issuecomment-2188172857.