### PR TITLE
Initial support for parameterization and skipif

### DIFF
--- a/docs-src/changelog.md
+++ b/docs-src/changelog.md
@@ -2,6 +2,10 @@
 HypoFuzz uses [calendar-based versioning](https://calver.org/), with a
 `YY-MM-patch` format.
 
+## 25.01.5
+
+Initial support for `@pytest.mark.parametrize` and `@pytest.mark.skipif`.
+
 ## 25.01.4
 
 Ignore standard library and dynamically generated code for coverage.

--- a/docs-src/changelog.md
+++ b/docs-src/changelog.md
@@ -4,7 +4,7 @@ HypoFuzz uses [calendar-based versioning](https://calver.org/), with a
 
 ## 25.01.5
 
-Initial support for `@pytest.mark.parametrize` and `@pytest.mark.skipif`.
+Support for `@pytest.mark.skip` and `@pytest.mark.skipif`, and initial support for `@pytest.mark.parametrize`.
 
 Also bumps Hypothesis to [6.124.0](https://hypothesis.readthedocs.io/en/latest/changes.html#v6.124.0), to support the new database format.
 

--- a/docs-src/changelog.md
+++ b/docs-src/changelog.md
@@ -6,6 +6,8 @@ HypoFuzz uses [calendar-based versioning](https://calver.org/), with a
 
 Initial support for `@pytest.mark.parametrize` and `@pytest.mark.skipif`.
 
+Also bumps Hypothesis to [6.124.0](https://hypothesis.readthedocs.io/en/latest/changes.html#v6.124.0), to support the new database format.
+
 ## 25.01.4
 
 Ignore standard library and dynamically generated code for coverage.

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setuptools.setup(
         "black >= 23.3.0",
         "coverage >= 5.2.1",
         "dash >= 2.0.0",
-        "hypothesis[cli] >= 6.123.12",
+        "hypothesis[cli] >= 6.124.0",
         "libcst >= 1.0.0",
         "pandas >= 1.0.0",
         "psutil >= 3.0.0",

--- a/src/hypofuzz/__init__.py
+++ b/src/hypofuzz/__init__.py
@@ -1,4 +1,4 @@
 """Adaptive fuzzing for property-based tests using Hypothesis."""
 
-__version__ = "25.01.4"
+__version__ = "25.01.5"
 __all__: list = []

--- a/src/hypofuzz/hy.py
+++ b/src/hypofuzz/hy.py
@@ -122,7 +122,7 @@ class FuzzProcess:
         # The actual fuzzer implementation
         self.random = Random(random_seed)
         self._test_fn = test_fn
-        self.__stuff = stuff
+        self._stuff = stuff
         self.nodeid = nodeid or test_fn.__qualname__
         self.database_key = database_key
 
@@ -270,13 +270,13 @@ class FuzzProcess:
                 # Note that the data generation and test execution happen in the same
                 # coverage context.  We may later split this, or tag each separately.
                 with collector:
-                    if self.__stuff.selfy is not None:
-                        data.hypothesis_runner = self.__stuff.selfy
+                    if self._stuff.selfy is not None:
+                        data.hypothesis_runner = self._stuff.selfy
                     # Generate all arguments to the test function.
-                    args = self.__stuff.args
-                    kwargs = dict(self.__stuff.kwargs)
+                    args = self._stuff.args
+                    kwargs = dict(self._stuff.kwargs)
                     kw, argslices = context.prep_args_kwargs_from_strategies(
-                        self.__stuff.given_kwargs
+                        self._stuff.given_kwargs
                     )
                     kwargs.update(kw)
 

--- a/src/hypofuzz/interface.py
+++ b/src/hypofuzz/interface.py
@@ -38,6 +38,9 @@ class _ItemsCollector:
         from .hy import FuzzProcess
 
         for item in session.items:
+            if list(item.iter_markers("skip")):
+                print(f"skipping {item=} due to an @skip mark")
+                continue
             if has_true_skipif(item):
                 print(f"skipping {item=} due to a true @skipif mark")
                 continue

--- a/src/hypofuzz/interface.py
+++ b/src/hypofuzz/interface.py
@@ -9,12 +9,23 @@ from inspect import signature
 from typing import TYPE_CHECKING, get_type_hints
 
 import pytest
+from _pytest.nodes import Node
+from _pytest.skipping import evaluate_condition
 from hypothesis.stateful import RuleBasedStateMachine, run_state_machine_as_test
 
 if TYPE_CHECKING:
     # We have to defer imports to within functions here, because this module
     # is a Hypothesis entry point and is thus imported earlier than the others.
     from .hy import FuzzProcess
+
+
+def has_true_skipif(item: Node) -> bool:
+    # multiple @skipif decorators are treated as an OR.
+    for mark in item.iter_markers("skipif"):
+        result, _reason = evaluate_condition(item, mark, condition=mark.args[0])
+        if result:
+            return True
+    return False
 
 
 class _ItemsCollector:
@@ -27,6 +38,9 @@ class _ItemsCollector:
         from .hy import FuzzProcess
 
         for item in session.items:
+            if has_true_skipif(item):
+                print(f"skipping {item=} due to a true @skipif mark")
+                continue
             # If the test takes a fixture, we skip it - the fuzzer doesn't have
             # pytest scopes, so we just can't support them.  TODO: note skips.
             manager = item._request._fixturemanager
@@ -34,11 +48,9 @@ class _ItemsCollector:
                 node=item, func=item.function, cls=None
             )
 
-            from _pytest.nodes import Node
-
             # from pytest 8.3 or thereabouts
             pytest83 = get_type_hints(manager._getautousenames).get("node") == Node
-            autouse_names = tuple(
+            autouse_names = set(
                 manager._getautousenames(item if pytest83 else item.nodeid)
             )
 
@@ -54,6 +66,12 @@ class _ItemsCollector:
                 # pytest ~6-7
                 _, all_autouse, _ = manager.getfixtureclosure(autouse_names, item)
 
+            all_autouse = set(all_autouse)
+            # from @pytest.mark.parametrize. Pytest gives us the params and their
+            # values directly, so we can pass them as extra kwargs to FuzzProcess.
+            params = item.callspec.params if hasattr(item, "callspec") else {}
+            param_names = set(params)
+
             # Skip any test which:
             # - directly requests a non autouse fixture, or
             # - requests any fixture (in its transitive closure) that isn't autouse
@@ -61,18 +79,23 @@ class _ItemsCollector:
             # We check both to handle the case where a function directly requests
             # a non autouse fixture, *and* that same fixture is requested by an
             # autouse fixture. This function should not be collected.
-            if (names := set(fixtureinfo.initialnames).difference(autouse_names)) or (
-                names := set(fixtureinfo.name2fixturedefs).difference(all_autouse)
+            #
+            # We also ignore any arguments from @pytest.mark.parametrize, which we know how to handle.
+            if (
+                names := set(fixtureinfo.initialnames).difference(
+                    autouse_names | param_names
+                )
+            ) or (
+                names := set(fixtureinfo.name2fixturedefs).difference(
+                    all_autouse | param_names
+                )
             ):
                 print(
                     f"skipping {item=} because of non-autouse fixtures {names}",
                     flush=True,
                 )
                 continue
-            # For parametrized tests, we have to pass the parametrized args into
-            # wrapped_test.hypothesis.get_strategy() to avoid trivial TypeErrors
-            # from missing required arguments.
-            extra_kw = item.callspec.params if hasattr(item, "callspec") else {}
+
             # Wrap it up in a FuzzTarget and we're done!
             try:
                 # Skip state-machine classes, since they're not
@@ -81,7 +104,7 @@ class _ItemsCollector:
                 else:
                     target = item.obj
                 fuzz = FuzzProcess.from_hypothesis_test(
-                    target, nodeid=item.nodeid, extra_kw=extra_kw
+                    target, nodeid=item.nodeid, extra_kw=params
                 )
                 self.fuzz_targets.append(fuzz)
             except Exception as err:

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -121,3 +121,34 @@ def test_skipif_collection(conditions, result):
     # if (any of) the skipif evaluated to true, we should not have collected this
     # test. Otherwise we should have.
     assert collect_names(code) == (set() if result else {"test_a"})
+
+    # same for a module-level mark
+    decorators = ", ".join(f"pytest.mark.skipif({c}, reason='')" for c in conditions)
+    code = f"""
+    pytestmark = {f'[{decorators}]' if len(conditions) > 1 else decorators}
+
+    @given(st.integers())
+    def test_a(n):
+        pass
+    """
+    assert collect_names(code) == (set() if result else {"test_a"})
+
+
+def test_skip_not_collected():
+    code = """
+    @pytest.mark.skip
+    @given(st.integers())
+    def test_a(n):
+        pass
+    """
+    assert not collect_names(code)
+
+    # same for a module-level mark
+    code = """
+    pytestmark = pytest.mark.skip
+
+    @given(st.integers())
+    def test_a(n):
+        pass
+    """
+    assert not collect_names(code)


### PR DESCRIPTION
Parametrized node ids Just Work ™️ in the dashboard....as long as you aren't doing anything too cursed, like duplicating names. Skipif is evaluated and skipped during collection, including support for condition strings.

I haven't tested this with more complicated things like classes or ~~module-level skips~~ (added tests for the latter). 

Also tacked on to this pull: update our database usage from buffer to choices.