### PR TITLE
Initial support for stateful testing

### DIFF
--- a/docs-src/changelog.md
+++ b/docs-src/changelog.md
@@ -2,6 +2,10 @@
 HypoFuzz uses [calendar-based versioning](https://calver.org/), with a
 `YY-MM-patch` format.
 
+## 25.02.2
+
+Initial support for [stateful tests](https://hypothesis.readthedocs.io/en/latest/stateful.html).
+
 ## 25.02.1
 
 Use a new mutator based on the typed choice sequence (https://github.com/HypothesisWorks/hypothesis/issues/3921), bringing back compatibility with new Hypothesis versions.

--- a/src/hypofuzz/__init__.py
+++ b/src/hypofuzz/__init__.py
@@ -1,4 +1,4 @@
 """Adaptive fuzzing for property-based tests using Hypothesis."""
 
-__version__ = "25.02.1"
+__version__ = "25.02.2"
 __all__: list = []

--- a/src/hypofuzz/interface.py
+++ b/src/hypofuzz/interface.py
@@ -4,14 +4,13 @@ import io
 import sys
 from collections.abc import Iterable
 from contextlib import redirect_stdout
-from functools import partial
 from inspect import signature
 from typing import TYPE_CHECKING, get_type_hints
 
 import pytest
 from _pytest.nodes import Node
 from _pytest.skipping import evaluate_condition
-from hypothesis.stateful import RuleBasedStateMachine, run_state_machine_as_test
+from hypothesis.stateful import get_state_machine_test
 
 if TYPE_CHECKING:
     # We have to defer imports to within functions here, because this module
@@ -71,6 +70,7 @@ class _ItemsCollector:
             # values directly, so we can pass them as extra kwargs to FuzzProcess.
             params = item.callspec.params if hasattr(item, "callspec") else {}
             param_names = set(params)
+            extra_kw = params
 
             # Skip any test which:
             # - directly requests a non autouse fixture, or
@@ -95,16 +95,23 @@ class _ItemsCollector:
                     flush=True,
                 )
                 continue
-
             # Wrap it up in a FuzzTarget and we're done!
             try:
-                # Skip state-machine classes, since they're not
-                if isinstance(item.obj, RuleBasedStateMachine.TestCase):
-                    target = partial(run_state_machine_as_test, item.obj)
+                if hasattr(item.obj, "_hypothesis_state_machine_class"):
+                    # I guess it's conceivable this is possible...I just don't see how!
+                    assert (
+                        extra_kw == {}
+                    ), "Not possible for RuleBasedStateMachine.TestCase to be parametrized (we think?)"
+                    runTest = item.obj
+                    StateMachineClass = runTest._hypothesis_state_machine_class
+                    target = get_state_machine_test(
+                        StateMachineClass, settings=runTest.__self__.settings
+                    )
+                    extra_kw = {"factory": StateMachineClass}
                 else:
                     target = item.obj
                 fuzz = FuzzProcess.from_hypothesis_test(
-                    target, nodeid=item.nodeid, extra_kw=params
+                    target, nodeid=item.nodeid, extra_kw=extra_kw
                 )
                 self.fuzz_targets.append(fuzz)
             except Exception as err:

--- a/src/hypofuzz/interface.py
+++ b/src/hypofuzz/interface.py
@@ -117,7 +117,7 @@ class _ItemsCollector:
                         # runTest is a function, not a bound method, under pyest7.
                         # I wonder if something about TestCase instantiation order
                         # changed in pytest 8? Either way, we can't access
-                        # __self__.settings uder pytest 7.
+                        # __self__.settings under pytest 7.
                         #
                         # I am going to call this an acceptably rare bug for now,
                         # because it should only manifest if the user sets a custom

--- a/src/hypofuzz/interface.py
+++ b/src/hypofuzz/interface.py
@@ -104,13 +104,12 @@ class _ItemsCollector:
             # Wrap it up in a FuzzTarget and we're done!
             try:
                 if hasattr(item.obj, "_hypothesis_state_machine_class"):
-                    # I guess it's conceivable this is possible...I just don't see how!
                     assert (
                         extra_kw == {}
-                    ), "Not possible for RuleBasedStateMachine.TestCase to be parametrized (we think?)"
+                    ), "Not possible for RuleBasedStateMachine.TestCase to be parametrized"
                     runTest = item.obj
                     StateMachineClass = runTest._hypothesis_state_machine_class
-                    target = get_state_machine_test(
+                    target = get_state_machine_test(  # type: ignore
                         StateMachineClass, settings=runTest.__self__.settings
                     )
                     extra_kw = {"factory": StateMachineClass}

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -16,6 +16,7 @@ def collect(code: str) -> list[FuzzProcess]:
             """
             import pytest
             from hypothesis import given, strategies as st
+            from hypothesis.stateful import RuleBasedStateMachine, Bundle, initialize, rule
             """
         )
         + "\n"
@@ -121,3 +122,28 @@ def test_skipif_collection(conditions, result):
     # if (any of) the skipif evaluated to true, we should not have collected this
     # test. Otherwise we should have.
     assert collect_names(code) == (set() if result else {"test_a"})
+
+
+def test_collects_stateful_test():
+    code = """
+    names = st.text(min_size=1).filter(lambda x: "/" not in x)
+
+    class NumberModifier(RuleBasedStateMachine):
+        folders = Bundle("folders")
+        files = Bundle("files")
+
+        @initialize(target=folders)
+        def init_folders(self):
+            return "/"
+
+        @rule(target=folders, parent=folders, name=names)
+        def create_folder(self, parent, name):
+            return f"{parent}/{name}"
+
+        @rule(target=files, parent=folders, name=names)
+        def create_file(self, parent, name):
+            return f"{parent}/{name}"
+
+    NumberModifierTest = NumberModifier.TestCase
+    """
+    assert collect_names(code) == {"run_state_machine"}


### PR DESCRIPTION
Closes #38. Depends on #50 for a clean merge.

This requires a small amount of refactoring Hypothesis-side, including setting a new `runTest._hypothesis_state_machine_class = cls` attribute. I don't have a *great* grasp of the stateful testing internals, so I may be overcomplicating things? It seems that what Hypofuzz really wants to access is the underlying `@given` which drives stateful test - and to get to that we need to rejig some code.

Here's the Hypothesis-side companion diff, which I can PR to Hypothesis:

```diff
diff --git a/hypothesis-python/src/hypothesis/stateful.py b/hypothesis-python/src/hypothesis/stateful.py
index f1dfa5205..ae8ccd36c 100644
--- a/hypothesis-python/src/hypothesis/stateful.py
+++ b/hypothesis-python/src/hypothesis/stateful.py
@@ -83,14 +83,7 @@ class TestCaseProperty:  # pragma: no cover
         raise AttributeError("Cannot delete TestCase")
 
 
-def run_state_machine_as_test(state_machine_factory, *, settings=None, _min_steps=0):
-    """Run a state machine definition as a test, either silently doing nothing
-    or printing a minimal breaking program and raising an exception.
-
-    state_machine_factory is anything which returns an instance of
-    RuleBasedStateMachine when called with no arguments - it can be a class or a
-    function. settings will be used to control the execution of the test.
-    """
+def get_state_machine_test(state_machine_factory, *, settings=None, _min_steps=0):
     if settings is None:
         try:
             settings = state_machine_factory.TestCase.settings
@@ -237,8 +230,21 @@ def run_state_machine_as_test(state_machine_factory, *, settings=None, _min_step
         state_machine_factory, "_hypothesis_internal_use_reproduce_failure", None
     )
     run_state_machine._hypothesis_internal_print_given_args = False
+    return run_state_machine
+
 
-    run_state_machine(state_machine_factory)
+def run_state_machine_as_test(state_machine_factory, *, settings=None, _min_steps=0):
+    """Run a state machine definition as a test, either silently doing nothing
+    or printing a minimal breaking program and raising an exception.
+
+    state_machine_factory is anything which returns an instance of
+    RuleBasedStateMachine when called with no arguments - it can be a class or a
+    function. settings will be used to control the execution of the test.
+    """
+    state_machine_test = get_state_machine_test(
+        state_machine_factory, settings=settings, _min_steps=_min_steps
+    )
+    state_machine_test(state_machine_factory)
 
 
 class StateMachineMeta(type):
@@ -437,6 +443,7 @@ class RuleBasedStateMachine(metaclass=StateMachineMeta):
                 run_state_machine_as_test(cls, settings=self.settings)
 
             runTest.is_hypothesis_test = True
+            runTest._hypothesis_state_machine_class = cls
 
         StateMachineTestCase.__name__ = cls.__name__ + ".TestCase"
         StateMachineTestCase.__qualname__ = cls.__qualname__ + ".TestCase"
```