### PR TITLE
Pin hypothesis to 6.124.3

### DIFF
--- a/docs-src/changelog.md
+++ b/docs-src/changelog.md
@@ -2,6 +2,10 @@
 HypoFuzz uses [calendar-based versioning](https://calver.org/), with a
 `YY-MM-patch` format.
 
+## 25.01.6
+
+Pin upper Hypothesis bound for compatibility, until we support new Hypothesis internals.
+
 ## 25.01.5
 
 Support for `@pytest.mark.skip` and `@pytest.mark.skipif`, and initial support for `@pytest.mark.parametrize`.

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setuptools.setup(
         "black >= 23.3.0",
         "coverage >= 5.2.1",
         "dash >= 2.0.0",
-        "hypothesis[cli] >= 6.124.0",
+        "hypothesis[cli] >= 6.124.0, < 6.124.4",
         "libcst >= 1.0.0",
         "pandas >= 1.0.0",
         "psutil >= 3.0.0",

--- a/src/hypofuzz/__init__.py
+++ b/src/hypofuzz/__init__.py
@@ -1,4 +1,4 @@
 """Adaptive fuzzing for property-based tests using Hypothesis."""
 
-__version__ = "25.01.5"
+__version__ = "25.01.6"
 __all__: list = []


### PR DESCRIPTION
We removed the buffer in `6.124.4` - whoops! I'll work on supporting this as my next task but may not be able to get to it until the weekend.