### PR TITLE
Set version when building

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hypofuzz"
-# read from __version__
+# see [tool.setuptools.dynamic]
 dynamic = ["version"]
 description = "Adaptive fuzzing for property-based tests"
 readme = "README.md"
@@ -68,6 +68,9 @@ hypofuzz = [
 hypofuzz = [
     "frontend/node_modules/**/*"
 ]
+
+[tool.setuptools.dynamic]
+version = {attr = "hypofuzz.__version__"}
 
 [tool.setuptools.cmdclass]
 "build_py" = "hypofuzz.build.HypofuzzBuildPy"


### PR DESCRIPTION
Latest CI attempt *built*, but with a version of 0.0.0, and so skipped the pypi upload. Apparently for the `setuptools` backend any dynamic attribute needs a matching [tool.setuptools.dynamic] key.