### PR TITLE
Use hypothesis pubsub

### DIFF
--- a/docs-src/changelog.md
+++ b/docs-src/changelog.md
@@ -2,6 +2,12 @@
 HypoFuzz uses [calendar-based versioning](https://calver.org/), with a
 `YY-MM-patch` format.
 
+## 25.02.5
+
+We now use the new [pub-sub database interface in Hypothesis](https://hypothesis.readthedocs.io/en/latest/changes.html#v6-126-0) to update the dashboard. Dashboard updates should be significantly more responsive and use less resources.
+
+This release is not compatible with old hypofuzz databases.
+
 ## 25.02.4
 
 Fix dashboard not getting properly built for pypi releases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ keywords = ["python", "testing", "fuzzing", "property-based-testing"]
 dependencies = [
     "black>=23.3.0",
     "coverage>=5.2.1",
-    "hypothesis[cli]>=6.125.3",
+    "hypothesis[cli]>=6.126.0",
     "libcst>=1.0.0", # for hypothesis.extra._patching
     "psutil>=3.0.0",
     "pytest>=6.0.1",
@@ -141,3 +141,19 @@ ignore = [
     "UP031",
     "UP037",
 ]
+
+[tool.mypy]
+python_version = "3.10"
+platform = "linux"
+allow_redefinition = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_untyped_decorators = true
+follow_imports = "silent"
+ignore_missing_imports = true
+implicit_reexport = false
+warn_no_return = true
+warn_return_any = true
+warn_unused_ignores = true
+warn_unused_configs = true
+warn_redundant_casts = true

--- a/src/hypofuzz/__init__.py
+++ b/src/hypofuzz/__init__.py
@@ -1,4 +1,4 @@
 """Adaptive fuzzing for property-based tests using Hypothesis."""
 
-__version__ = "25.02.4"
+__version__ = "25.02.5"
 __all__: list = []

--- a/src/hypofuzz/dashboard.py
+++ b/src/hypofuzz/dashboard.py
@@ -1,7 +1,10 @@
 """Live web dashboard for a fuzzing run."""
 
+import abc
 import atexit
+import json
 import signal
+import time
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Optional
@@ -10,6 +13,8 @@ import black
 import trio
 from hypercorn.config import Config
 from hypercorn.trio import serve
+from hypothesis.database import ListenerEventT
+from sortedcontainers import SortedList
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
@@ -19,32 +24,160 @@ from starlette.routing import Mount, Route, WebSocketRoute
 from starlette.staticfiles import StaticFiles
 from starlette.websockets import WebSocket, WebSocketDisconnect
 
-from .database import get_db
+from .database import Metadata, Report, get_db, metadata_key, reports_key
 from .patching import make_and_save_patches
 
-DATA_TO_PLOT: dict = {}
-LAST_UPDATE: dict = {}
+
+class HypofuzzEncoder(json.JSONEncoder):
+    def default(self, obj: object) -> object:
+        if isinstance(obj, SortedList):
+            return list(obj)
+        return super().default(obj)
+
+
+class HypofuzzWebsocket(abc.ABC):
+    def __init__(self, websocket: WebSocket) -> None:
+        self.websocket = websocket
+
+    async def accept(self) -> None:
+        await self.websocket.accept()
+
+    async def receive_json(self) -> None:
+        await self.websocket.receive_json()
+
+    async def send_json(self, data: Any) -> None:
+        await self.websocket.send_text(json.dumps(data, cls=HypofuzzEncoder))
+
+    @abc.abstractmethod
+    async def initial(
+        self, reports: dict[str, list[Report]], metadata: dict[str, Metadata]
+    ) -> None:
+        pass
+
+    @abc.abstractmethod
+    async def on_event(self, event_type: str, data: Any) -> None:
+        pass
+
+
+class OverviewWebsocket(HypofuzzWebsocket):
+    async def initial(
+        self, reports: dict[str, list[Report]], metadata: dict[str, Metadata]
+    ) -> None:
+        await self.send_json(
+            {"type": "initial", "reports": reports, "metadata": metadata}
+        )
+
+    async def on_event(self, event_type: str, data: Any) -> None:
+        if event_type == "save":
+            await self.send_json({"type": "save", "data": data})
+
+
+class TestWebsocket(HypofuzzWebsocket):
+    def __init__(self, websocket: WebSocket, node_id: str) -> None:
+        super().__init__(websocket)
+        self.node_id = node_id
+
+    async def initial(
+        self, reports: dict[str, list[Report]], metadata: dict[str, Metadata]
+    ) -> None:
+        # match same shape as overview for now (mapping of node id to data)
+        # TODO refactor this, drop the nesting and fix the types typescript-side
+        await self.send_json(
+            {
+                "type": "initial",
+                "reports": {self.node_id: reports[self.node_id]},
+                "metadata": {self.node_id: metadata[self.node_id]},
+            }
+        )
+
+    async def on_event(self, event_type: str, data: Any) -> None:
+        if event_type == "save":
+            node_id = data["nodeid"]
+            if node_id != self.node_id:
+                return
+            await self.send_json({"type": "save", "data": data})
+
+        if event_type == "metadata":
+            node_id = data["nodeid"]
+            if node_id != self.node_id:
+                return
+            await self.send_json({"type": "metadata", "data": data})
+
+        # TODO handle delete and refresh events
+
+
+REPORTS: dict[str, SortedList[Report]] = defaultdict(
+    lambda: SortedList(key=lambda r: r["elapsed_time"])
+)
+METADATA: dict[str, Metadata] = {}
 PYTEST_ARGS: Optional[list[str]] = None
-active_connections: set[WebSocket] = set()
+websockets: set[HypofuzzWebsocket] = set()
+delete_debounce = 300
+refreshed_at: dict[bytes, float] = defaultdict(int)
 
 
 async def websocket(websocket: WebSocket) -> None:
+    websocket = (
+        TestWebsocket(websocket, node_id)
+        if (node_id := websocket.query_params.get("node_id"))
+        else OverviewWebsocket(websocket)
+    )
     await websocket.accept()
-    active_connections.add(websocket)
+    websockets.add(websocket)
+    await websocket.initial(REPORTS, METADATA)
+
     try:
         while True:
             await websocket.receive_json()
     except WebSocketDisconnect:
-        active_connections.remove(websocket)
+        websockets.remove(websocket)
 
 
-async def broadcast_update(data: dict) -> None:
-    # copy since we might modify it
-    for connection in set(active_connections):
-        try:
-            await connection.send_json(data)
-        except WebSocketDisconnect:
-            active_connections.remove(connection)
+async def broadcast_event(event_type: str, data: dict) -> None:
+    for websocket in websockets:
+        await websocket.on_event(event_type, data)
+
+
+def database_listener(event: ListenerEventT) -> None:
+    event_type, args = event
+    if event_type == "save":
+        key, value = args
+        assert value is not None
+        if key.endswith(reports_key):
+            report = json.loads(value)
+            REPORTS[report["nodeid"]].add(report)
+            trio.run(broadcast_event, "save", report)
+        if key.endswith(metadata_key):
+            metadata = json.loads(value)
+            METADATA[metadata["nodeid"]] = metadata
+            trio.run(broadcast_event, "metadata", metadata)
+
+    if event_type == "delete":
+        key, value = args
+
+        if key.endswith(reports_key):
+            key = key.rstrip(reports_key)
+            if value is not None:
+                report = json.loads(value)
+                REPORTS[report["nodeid"]].remove(report)
+                trio.run(broadcast_event, "delete", report)
+            else:
+                # debounce each key, to relieve db read pressure for this expensive
+                # re-scan. Deletions aren't important for correctness, just
+                # performance / memory.
+                if time.time() - refreshed_at[key] > delete_debounce:
+                    reports = SortedList(
+                        list(get_db().fetch_reports(key)),
+                        key=lambda r: r["elapsed_time"],
+                    )
+                    if reports:
+                        node_id = reports[0]["nodeid"]
+                        REPORTS[node_id] = reports
+                        trio.run(broadcast_event, "refresh", reports)
+                    refreshed_at[key] = time.time()
+
+        # We're only keeping a reference to the latest metadata, so we don't need
+        # to bother handling deletion events for it, just save.
 
 
 def try_format(code: str) -> str:
@@ -55,16 +188,18 @@ def try_format(code: str) -> str:
 
 
 async def api_tests(request: Request) -> Response:
-    return JSONResponse(DATA_TO_PLOT)
+    # ideally we'd use HypofuzzEncoder here, but JSONResponse doesn't accept an encoder
+    reports = {node_id: list(reports) for node_id, reports in REPORTS.items()}
+    return JSONResponse(reports)
 
 
 async def api_test(request: Request) -> Response:
     node_id = request.path_params["node_id"]
-    return JSONResponse(DATA_TO_PLOT[node_id])
+    return JSONResponse(list(REPORTS[node_id]))
 
 
 async def api_patches(request: Request) -> Response:
-    patches = make_and_save_patches(PYTEST_ARGS, LAST_UPDATE)
+    patches = make_and_save_patches(PYTEST_ARGS, REPORTS, METADATA)
 
     return JSONResponse(
         {name: str(patch_path.read_text()) for name, patch_path in patches.items()}
@@ -87,33 +222,6 @@ async def api_pycrunch_file(request: Request) -> Response:
         return Response(status_code=404)
 
     return FileResponse(path=path, media_type="application/octet-stream")
-
-
-async def poll_database_forever() -> None:
-    previous_data = None
-    while True:
-        await poll_database()
-        # TODO use hypothesis db listening
-        if DATA_TO_PLOT != previous_data:
-            await broadcast_update(DATA_TO_PLOT)
-            previous_data = dict(DATA_TO_PLOT)
-        await trio.sleep(1)
-
-
-async def poll_database() -> None:
-    global DATA_TO_PLOT
-
-    db = get_db()
-    data: list = []
-    for key in db.fetch(b"hypofuzz-test-keys"):
-        data.extend(db.fetch_metadata(key))
-    data.sort(key=lambda d: d["elapsed_time"])
-
-    DATA_TO_PLOT = defaultdict(list)
-    for d in data:
-        DATA_TO_PLOT[d["nodeid"]].append(d)
-        LAST_UPDATE[d["nodeid"]] = d
-    DATA_TO_PLOT = dict(DATA_TO_PLOT)
 
 
 dist = Path(__file__).parent / "frontend" / "dist"
@@ -151,7 +259,6 @@ async def serve_app(app: Any, host: str, port: str) -> None:
 
 async def run_dashboard(port: int, host: str) -> None:
     async with trio.open_nursery() as nursery:
-        nursery.start_soon(poll_database_forever)
         nursery.start_soon(serve_app, app, host, port)
 
 
@@ -166,10 +273,11 @@ def start_dashboard_process(
     # we run a pytest collection step for the dashboard to pick up on databases
     # from custom profiles.
     _get_hypothesis_tests_with_pytest(pytest_args)
+    get_db()._db.add_listener(database_listener)
 
     # Ensure that we dump whatever patches are ready before shutting down
     def signal_handler(signum, frame):  # type: ignore
-        make_and_save_patches(pytest_args, LAST_UPDATE)
+        make_and_save_patches(pytest_args, REPORTS, METADATA)
         if old_handler in (signal.SIG_DFL, None):
             return old_handler
         elif old_handler is not signal.SIG_IGN:
@@ -177,7 +285,7 @@ def start_dashboard_process(
         raise NotImplementedError("Unreachable")
 
     old_handler = signal.signal(signal.SIGTERM, signal_handler)
-    atexit.register(make_and_save_patches, pytest_args, LAST_UPDATE)
+    atexit.register(make_and_save_patches, pytest_args, REPORTS, METADATA)
 
     print(f"\n\tNow serving dashboard at  http://{host}:{port}/\n")
     trio.run(run_dashboard, port, host)

--- a/src/hypofuzz/database.py
+++ b/src/hypofuzz/database.py
@@ -1,22 +1,58 @@
 import json
 from collections.abc import Iterable
 from functools import cache
-from typing import Any
+from typing import Any, Optional, TypedDict
 
 from hypothesis import settings
 from hypothesis.database import BackgroundWriteDatabase, ExampleDatabase
 
-# TODO TypedDict
-Report = dict[str, Any]
+
+class WorkerT(TypedDict):
+    pid: int
+    hostname: str
+    pod_name: Optional[str]
+    pod_namespace: Optional[str]
+    node_name: Optional[str]
+    pod_ip: Optional[str]
+    container_id: Optional[str]
 
 
-def metadata_key(key: bytes) -> bytes:
-    return key + b".hypofuzz.metadata"
+# Conceptually:
+# * A report is an incremental progress marker which we don't want to delete,
+#   because seeing intermediary stages in e.g. a graph is useful information
+# * Ketadata is the latest status of a test, which we might update to something
+#   different if new information comes along. Intermediate metadata steps are
+#   not saved because they are not interesting.
+class Report(TypedDict):
+    nodeid: str
+    elapsed_time: float
+    timestamp: float
+    worker: WorkerT
+    ninputs: int
+    branches: int
+    since_new_cov: Optional[int]
+    loaded_from_db: int
+    note: str
+
+
+class Metadata(TypedDict):
+    nodeid: str
+    seed_pool: list[list[str]]
+    failures: list[list[str]]
+    status_counts: dict[str, int]
+    # TODO also add a note here?
+
+
+reports_key = b".hypofuzz.reports"
+metadata_key = b".hypofuzz.metadata"
 
 
 class HypofuzzDatabase:
     def __init__(self, db: ExampleDatabase) -> None:
         self._db = db
+
+    def _encode(self, data: Any) -> bytes:
+        return bytes(json.dumps(data), "ascii")
 
     def save(self, key: bytes, value: bytes) -> None:
         self._db.save(key, value)
@@ -27,14 +63,30 @@ class HypofuzzDatabase:
     def delete(self, key: bytes, value: bytes) -> None:
         self._db.delete(key, value)
 
-    def save_metadata(self, key: bytes, report: Report) -> None:
-        self._db.save(metadata_key(key), bytes(json.dumps(report), "ascii"))
+    def save_report(self, key: bytes, report: Report) -> None:
+        self.save(key + reports_key, self._encode(report))
 
-    def delete_metadata(self, key: bytes, report: Report) -> None:
-        self._db.delete(metadata_key(key), bytes(json.dumps(report), "ascii"))
+    def delete_report(self, key: bytes, report: Report) -> None:
+        self.delete(key + reports_key, self._encode(report))
 
-    def fetch_metadata(self, key: bytes) -> Iterable[Report]:
-        return [json.loads(e) for e in self._db.fetch(metadata_key(key))]
+    def fetch_reports(self, key: bytes) -> Iterable[Report]:
+        return [json.loads(e) for e in self.fetch(key + reports_key)]
+
+    def fetch_metadata(self, key: bytes) -> Iterable[Metadata]:
+        return [json.loads(e) for e in self.fetch(key + metadata_key)]
+
+    def replace_metadata(self, key: bytes, metadata: Metadata) -> None:
+        # save and then delete to avoid intermediary state where no metadata is
+        # in the db. > 1 metadata is better than 0
+        old_metadatas = list(self.fetch_metadata(key))
+
+        self.save(key + metadata_key, self._encode(metadata))
+        for old_metadata in old_metadatas:
+            if old_metadata == metadata:
+                # don't remove something equal to the thing we just saved. This
+                # would cause us to reset to zero entries.
+                continue
+            self.delete(key + metadata_key, self._encode(old_metadata))
 
 
 # cache to make the db a singleton. We defer creation until first-usage to ensure

--- a/src/hypofuzz/entrypoint.py
+++ b/src/hypofuzz/entrypoint.py
@@ -118,8 +118,11 @@ def _fuzz_impl(numprocesses: int, unsafe: bool, pytest_args: tuple[str, ...]) ->
     # With our arguments validated, it's time to actually do the work.
     tests = _get_hypothesis_tests_with_pytest(pytest_args)
     if not tests:
-        raise click.UsageError("No property-based tests were collected")
-    print(f"{tests=}")
+        raise click.UsageError(
+            f"No property-based tests were collected. args: {pytest_args}"
+        )
+
+    print(f"collected {len(tests)} property-based tests")
     if numprocesses > len(tests) and not unsafe:
         numprocesses = len(tests)
 

--- a/src/hypofuzz/frontend/src/App.tsx
+++ b/src/hypofuzz/frontend/src/App.tsx
@@ -7,16 +7,21 @@ import { Layout } from './components/Layout'
 
 export function App() {
   return (
-    <WebSocketProvider>
-      <BrowserRouter>
-        <Routes>
-          <Route element={<Layout />}>
-            <Route path="/" element={<TestsPage />} />
-            <Route path="/patches" element={<PatchesPage />} />
-            <Route path="/tests/:testId" element={<TestPage />} />
-          </Route>
-        </Routes>
-      </BrowserRouter>
-    </WebSocketProvider>
+    <BrowserRouter>
+      <Routes>
+        <Route element={<Layout />}>
+          <Route
+            path="/"
+            element={
+              <WebSocketProvider>
+                <TestsPage />
+              </WebSocketProvider>
+            }
+          />
+          <Route path="/patches" element={<PatchesPage />}/>
+          <Route path="/tests/:testId" element={<TestPage />}/>
+        </Route>
+      </Routes>
+    </BrowserRouter>
   )
 }

--- a/src/hypofuzz/frontend/src/pages/Tests.tsx
+++ b/src/hypofuzz/frontend/src/pages/Tests.tsx
@@ -3,13 +3,13 @@ import { CoverageGraph } from '../components/CoverageGraph'
 import { useWebSocket } from '../context/WebSocketContext'
 
 export function TestsPage() {
-  const { data } = useWebSocket()
+  const { reports, metadata } = useWebSocket()
 
   return (
     <div className="dashboard">
-      <CoverageGraph data={data} />
+      <CoverageGraph reports={reports}/>
       <h2>Tests</h2>
-      <TestTable data={data} />
+      <TestTable reports={reports} metadata={metadata} />
     </div>
   )
 }

--- a/src/hypofuzz/frontend/src/types/dashboard.ts
+++ b/src/hypofuzz/frontend/src/types/dashboard.ts
@@ -1,4 +1,4 @@
-export interface TestRecord {
+export interface Report {
   nodeid: string;
   elapsed_time: number;
   timestamp: number;
@@ -6,8 +6,12 @@ export interface TestRecord {
   branches: number;
   since_new_cov: number | null;
   loaded_from_db: number;
+  note: string;
+}
+
+export interface Metadata {
+  nodeid: string;
   status_counts: Record<string, number>;
   seed_pool: any;
-  note: string;
   failures?: string[];
 }

--- a/src/hypofuzz/frontend/src/utils/testStats.ts
+++ b/src/hypofuzz/frontend/src/utils/testStats.ts
@@ -1,4 +1,4 @@
-import { TestRecord } from '../types/dashboard';
+import { Report } from '../types/dashboard';
 
 export interface TestStats {
   inputs: string;
@@ -15,9 +15,7 @@ function formatTime(seconds: number): string {
   return `${minutes}:${remainingSeconds.toString().padStart(2, '0')}`;
 };
 
-export function getTestStats(latest: TestRecord): TestStats {
-
-
+export function getTestStats(latest: Report): TestStats {
   const perSecond = latest.elapsed_time > 0
     ? Math.round((latest.loaded_from_db + latest.ninputs) / latest.elapsed_time)
     : 0;

--- a/tests/test_fuzz_process.py
+++ b/tests/test_fuzz_process.py
@@ -39,7 +39,7 @@ def test_fuzz_one_process_explain_mode():
 
     # Check that we got the expected failure, including message + explain-mode output.
     assert fp.status_counts[Status.INTERESTING.name] >= 1
-    (call_repr, _, _, tb_repr), *rest = fp._json_description["failures"]
+    (call_repr, _, _, tb_repr), *rest = fp._metadata["failures"]
     assert not rest  # expected only one failure
     assert tb_repr.endswith("test_fuzz_process.CustomError: x=1\n")
     assert call_repr == "failing_pbt(\n    x=1,\n    y=0,\n)"

--- a/tox.ini
+++ b/tox.ini
@@ -52,22 +52,6 @@ addopts =
     # --cov-report=term-missing:skip-covered
     # --cov-fail-under=100
 
-[mypy]
-python_version = 3.10
-platform = linux
-allow_redefinition = True
-disallow_untyped_calls = True
-disallow_untyped_defs = True
-disallow_untyped_decorators = True
-follow_imports = silent
-ignore_missing_imports = True
-implicit_reexport = False
-warn_no_return = True
-warn_return_any = True
-warn_unused_ignores = True
-warn_unused_configs = True
-warn_redundant_casts = True
-
 [coverage:report]
 exclude_lines =
     pragma: no cover


### PR DESCRIPTION
* deletions with an unknown value are expensive to rescan, so I've debounced this pretty heavily at 5 minutes (and could go further). It only matters for dropping intermediary points for performance, so timing isn't too important.
* I've split database entries into `Report` and `Metadata`. The latter is where "items which are expensive and I only need to know their very latest state" live, like the seed pool. Only transmitting Reports through the websocket, not Metadata, helps a lot with bandwidth usage. Also helps db size because we were previously leaving around some `seed_pool` entries in intermediary reports if you stopped+started the server a bunch.

Depends on https://github.com/HypothesisWorks/hypothesis/pull/4270 (I'm going to look into the flaky linux failure in that pr next)