### PR TITLE
Fix example dashboard build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       run: |
         HYPOFUZZ_DOCS_OUTPUT_DIR=docs/docs python -m tox --recreate -e docs
         HYPOFUZZ_DOCS_OUTPUT_DIR=docs/${BASE}/docs python -m tox --recreate -e docs
-        VITE_ROUTER_TYPE=hash npm run build --prefix src/hypofuzz/frontend -- --base=${BASE}/example-dashboard
+        VITE_ROUTER_TYPE=hash npm run build --prefix src/hypofuzz/frontend -- --base=${BASE%/}/example-dashboard
 
         rm -rf docs/${BASE}/example-dashboard
         mkdir -p docs/${BASE}/example-dashboard


### PR DESCRIPTION
no guarantees, but let's try this

apparently in vite `--base=//example-dashboard` != `--base=/example-dashboard`