### PR TITLE
Improve mobile table ui

### DIFF
--- a/docs-src/changelog.md
+++ b/docs-src/changelog.md
@@ -2,6 +2,10 @@
 HypoFuzz uses [calendar-based versioning](https://calver.org/), with a
 `YY-MM-patch` format.
 
+## 25.04.10
+
+Improve test table ui on mobile.
+
 ## 25.04.9
 
 Also filter the coverage graph when filtering the test table, and fix failures for parametrized tests being written to the incorrect database key.

--- a/src/hypofuzz/__init__.py
+++ b/src/hypofuzz/__init__.py
@@ -1,4 +1,4 @@
 """Adaptive fuzzing for property-based tests using Hypothesis."""
 
-__version__ = "25.04.9"
+__version__ = "25.04.10"
 __all__: list = []

--- a/src/hypofuzz/frontend/src/components/CoverageGraph.tsx
+++ b/src/hypofuzz/frontend/src/components/CoverageGraph.tsx
@@ -63,7 +63,7 @@ class Graph {
     this.xValue = (report: Report) =>
       axisSetting == "time" ? report.elapsed_time : report.ninputs
 
-    this.margin = { top: 20, right: 150, bottom: 45, left: 60 }
+    this.margin = { top: 20, right: 20, bottom: 45, left: 60 }
     this.width = svg.clientWidth - this.margin.left - this.margin.right
     this.height = 300 - this.margin.top - this.margin.bottom
 
@@ -204,7 +204,6 @@ class Graph {
       })
 
     this.drawLines()
-    this.drawLegend()
   }
 
   zoomTo(transform: d3.ZoomTransform, zoomY: boolean) {

--- a/src/hypofuzz/frontend/src/components/Table.tsx
+++ b/src/hypofuzz/frontend/src/components/Table.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, ReactNode } from "react"
+import React, { useState, useMemo, ReactNode, useEffect } from "react"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import {
   faArrowUp,
@@ -9,7 +9,6 @@ import {
 interface TableHeader<T> {
   content: ReactNode
   sortKey?: (item: T) => string | number
-  filterable?: boolean
   align?: string
 }
 
@@ -17,7 +16,9 @@ interface TableProps<T> {
   headers: TableHeader<T>[]
   data: T[]
   row: (item: T) => React.ReactNode[]
+  mobileRow?: (item: T) => React.ReactNode
   getKey?: (item: T) => string | number
+  filterStrings?: (item: T) => string[]
   onFilterChange?: (filter: string) => void
 }
 
@@ -26,44 +27,39 @@ enum SortOrder {
   DESC = 1,
 }
 
-function textContent(node: React.ReactNode): string {
-  if (typeof node === "string") {
-    return node
-  }
-  if (React.isValidElement(node)) {
-    return React.Children.toArray(node.props.children)
-      .map(child => textContent(child))
-      .join(" ")
-  }
-  return ""
-}
-
 export function Table<T>({
   headers,
   data,
   row,
+  mobileRow,
   getKey,
   onFilterChange,
+  filterStrings,
 }: TableProps<T>) {
   const [sortColumn, setSortColumn] = useState<number | null>(null)
   const [sortDirection, setSortDirection] = useState<SortOrder>(SortOrder.ASC)
   const [filterString, setFilterString] = useState("")
+  const [isMobile, setIsMobile] = useState(false)
+
+  useEffect(() => {
+    function checkIfMobile() {
+      setIsMobile(window.matchMedia("(max-width: 768px)").matches)
+    }
+    checkIfMobile()
+    window.addEventListener("resize", checkIfMobile)
+    return () => window.removeEventListener("resize", checkIfMobile)
+  }, [])
 
   const displayData = useMemo(() => {
     let displayData = data
 
     if (filterString) {
       displayData = data.filter(item => {
-        const rowValues = row(item)
-        // TODO if this gets expensive, precompute/cache the fitlerable text for each row
-        const filterText = headers
-          .filter(header => header.filterable)
-          .map(header => {
-            const row = rowValues[headers.indexOf(header)]
-            return textContent(row).toLowerCase()
-          })
-          .join(" ")
-        return filterText.includes(filterString.toLowerCase())
+        if (filterStrings) {
+          return filterStrings(item).some(checkString =>
+            checkString.toLowerCase().includes(filterString.toLowerCase()),
+          )
+        }
       })
     }
 
@@ -77,7 +73,17 @@ export function Table<T>({
       const result = aValue < bValue ? -1 : aValue > bValue ? 1 : 0
       return sortDirection === SortOrder.ASC ? result : -result
     })
-  }, [data, sortColumn, sortDirection, headers, filterString, row])
+  }, [
+    data,
+    sortColumn,
+    sortDirection,
+    headers,
+    filterString,
+    row,
+    filterStrings,
+    mobileRow,
+    isMobile,
+  ])
 
   const handleHeaderClick = (index: number) => {
     if (!headers[index].sortKey) return
@@ -100,7 +106,7 @@ export function Table<T>({
   return (
     <div className="table">
       {/* only show filter box if some rows are filterable */}
-      {headers.some(header => header.filterable) && (
+      {filterStrings !== undefined && (
         <div className="table__filter">
           <input
             type="text"
@@ -119,59 +125,65 @@ export function Table<T>({
           )}
         </div>
       )}
-      <table className="table__table">
-        <thead>
-          <tr>
-            {headers.map((header, index) => (
-              <th
-                key={index}
-                onClick={() => handleHeaderClick(index)}
-                className={header.sortKey ? "table--sortable" : ""}
-              >
-                <div
-                  className={`table__header table__header--${header.align ?? "left"}`}
+      {mobileRow !== undefined && isMobile ? (
+        displayData.map(item => (
+          <div key={getKey ? getKey(item) : undefined}>{mobileRow(item)}</div>
+        ))
+      ) : (
+        <table className="table__table">
+          <thead>
+            <tr>
+              {headers.map((header, index) => (
+                <th
+                  key={index}
+                  onClick={() => handleHeaderClick(index)}
+                  className={header.sortKey ? "table--sortable" : ""}
                 >
-                  {header.content}
-                  {header.sortKey && (
-                    <div className="table__sort">
-                      {[SortOrder.ASC, SortOrder.DESC].map(order => (
-                        <div
-                          className={`table__sort__arrow table__sort__arrow--${
-                            order === SortOrder.ASC ? "asc" : "desc"
-                          } ${
-                            sortColumn === index && sortDirection === order
-                              ? "table__sort__arrow--active"
-                              : ""
-                          }`}
-                        >
-                          {order === SortOrder.ASC ? (
-                            <FontAwesomeIcon icon={faArrowUp} />
-                          ) : (
-                            <FontAwesomeIcon icon={faArrowDown} />
-                          )}
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {displayData.map(item => {
-            const rowValue = row(item)
-            console.assert(rowValue.length === headers.length)
-            return (
-              <tr key={getKey ? getKey(item) : undefined}>
-                {rowValue.map((cell, colIndex) => (
-                  <td key={colIndex}>{cell}</td>
-                ))}
-              </tr>
-            )
-          })}
-        </tbody>
-      </table>
+                  <div
+                    className={`table__header table__header--${header.align ?? "left"}`}
+                  >
+                    {header.content}
+                    {header.sortKey && (
+                      <div className="table__sort">
+                        {[SortOrder.ASC, SortOrder.DESC].map(order => (
+                          <div
+                            className={`table__sort__arrow table__sort__arrow--${
+                              order === SortOrder.ASC ? "asc" : "desc"
+                            } ${
+                              sortColumn === index && sortDirection === order
+                                ? "table__sort__arrow--active"
+                                : ""
+                            }`}
+                          >
+                            {order === SortOrder.ASC ? (
+                              <FontAwesomeIcon icon={faArrowUp} />
+                            ) : (
+                              <FontAwesomeIcon icon={faArrowDown} />
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {displayData.map(item => {
+              const rowValue = row(item)
+              console.assert(rowValue.length === headers.length)
+              return (
+                <tr key={getKey ? getKey(item) : undefined}>
+                  {rowValue.map((cell, colIndex) => (
+                    <td key={colIndex}>{cell}</td>
+                  ))}
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      )}
       {filterString && displayData.length < data.length && (
         <div className="table__filter-status">
           Showing {displayData.length} of {data.length} rows

--- a/src/hypofuzz/frontend/src/components/TestTable.tsx
+++ b/src/hypofuzz/frontend/src/components/TestTable.tsx
@@ -1,7 +1,12 @@
 import { Link } from "react-router-dom"
 import { Report, Metadata } from "../types/dashboard"
 import { Table } from "./Table"
-import { getTestStats, inputsPerSecond, getStatus } from "../utils/testStats"
+import {
+  getTestStats,
+  inputsPerSecond,
+  getStatus,
+  Status,
+} from "../utils/testStats"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import {
   faHashtag,
@@ -12,6 +17,35 @@ import {
 } from "@fortawesome/free-solid-svg-icons"
 import { StatusPill } from "./StatusPill"
 import { Tooltip } from "./Tooltip"
+import { IconDefinition } from "@fortawesome/fontawesome-svg-core"
+
+function Icon({ icon, tooltip }: { icon: IconDefinition; tooltip: string }) {
+  return (
+    <Tooltip
+      content={
+        <div className="table__header__icon">
+          <FontAwesomeIcon icon={icon} />
+        </div>
+      }
+      tooltip={tooltip}
+    />
+  )
+}
+
+function InlineStatistic({
+  icon,
+  value,
+}: {
+  icon: React.ReactNode
+  value: React.ReactNode
+}) {
+  return (
+    <div className="table__inline-statistic">
+      {icon}
+      <span className="table__inline-statistic__value">{value}</span>
+    </div>
+  )
+}
 
 interface Props {
   reports: Map<string, Report[]>
@@ -38,11 +72,24 @@ export function TestTable({ reports, metadata, onFilterChange }: Props) {
     })
     .map(([nodeid, reports]) => ({ reports, metadata: metadata.get(nodeid)! }))
 
+  const inputsIcon = <Icon icon={faHashtag} tooltip="Number of inputs" />
+  const iconBranches = (
+    <Icon icon={faCodeBranch} tooltip="Number of branches executed" />
+  )
+  const iconExecutions = (
+    <Icon icon={faTachometerAlt} tooltip="Inputs per second" />
+  )
+  const iconSinceNewBranch = (
+    <Icon icon={faSeedling} tooltip="Number of inputs since a new branch" />
+  )
+  const iconTimeSpent = (
+    <Icon icon={faClock} tooltip="Total time spent running" />
+  )
+
   const headers = [
     {
       content: "Test",
       sortKey: (item: TestRow) => item.metadata.nodeid,
-      filterable: true,
     },
     {
       content: "Status",
@@ -53,80 +100,32 @@ export function TestTable({ reports, metadata, onFilterChange }: Props) {
         return 2
       },
       align: "center",
-      filterable: true,
     },
     {
-      content: (
-        <div style={{ textAlign: "right" }}>
-          <Tooltip
-            content={
-              <div className="table__header__icon">
-                <FontAwesomeIcon icon={faHashtag} />
-              </div>
-            }
-            tooltip="Number of inputs"
-          />
-        </div>
-      ),
+      content: inputsIcon,
       align: "right",
       sortKey: (item: TestRow) => item.reports[item.reports.length - 1].ninputs,
     },
     {
-      content: (
-        <Tooltip
-          content={
-            <div className="table__header__icon">
-              <FontAwesomeIcon icon={faCodeBranch} />
-            </div>
-          }
-          tooltip="Number of branches executed"
-        />
-      ),
+      content: iconBranches,
       align: "right",
       sortKey: (item: TestRow) =>
         item.reports[item.reports.length - 1].branches,
     },
     {
-      content: (
-        <Tooltip
-          content={
-            <div className="table__header__icon">
-              <FontAwesomeIcon icon={faTachometerAlt} />
-            </div>
-          }
-          tooltip="Inputs per second"
-        />
-      ),
+      content: iconExecutions,
       align: "right",
       sortKey: (item: TestRow) =>
         inputsPerSecond(item.reports[item.reports.length - 1]),
     },
     {
-      content: (
-        <Tooltip
-          content={
-            <div className="table__header__icon">
-              <FontAwesomeIcon icon={faSeedling} />
-            </div>
-          }
-          tooltip="Number of inputs since a new branch"
-        />
-      ),
+      content: iconSinceNewBranch,
       align: "right",
       sortKey: (item: TestRow) =>
         item.reports[item.reports.length - 1].since_new_cov ?? 0,
     },
     {
-      content: (
-        <Tooltip
-          content={
-            <div className="table__header__icon">
-              <FontAwesomeIcon icon={faClock} />
-            </div>
-          }
-          tooltip="Total time spent running"
-        />
-      ),
+      content: iconTimeSpent,
       align: "right",
       sortKey: (item: TestRow) =>
         item.reports[item.reports.length - 1].elapsed_time,
@@ -167,6 +166,43 @@ export function TestTable({ reports, metadata, onFilterChange }: Props) {
     ]
   }
 
+  function mobileRow(item: TestRow) {
+    const latest = item.reports[item.reports.length - 1]
+    const stats = getTestStats(latest)
+    const status = getStatus(latest, item.metadata)
+
+    return (
+      <div className="table__mobile-row">
+        <div className="table__mobile-row__header">
+          <Link
+            to={`/tests/${encodeURIComponent(latest.nodeid)}`}
+            className="test__link"
+            style={{ wordBreak: "break-all" }}
+          >
+            {latest.nodeid}
+          </Link>
+          <StatusPill status={status} />
+        </div>
+        <div className="table__mobile-row__statistics">
+          <InlineStatistic icon={inputsIcon} value={stats.inputs} />
+          <InlineStatistic icon={iconBranches} value={stats.branches} />
+          <InlineStatistic icon={iconExecutions} value={stats.executions} />
+          <InlineStatistic
+            icon={iconSinceNewBranch}
+            value={stats.inputsSinceBranch}
+          />
+          <InlineStatistic icon={iconTimeSpent} value={stats.timeSpent} />
+        </div>
+      </div>
+    )
+  }
+
+  function filterStrings(item: TestRow) {
+    const latest = item.reports[item.reports.length - 1]
+    const status = getStatus(latest, item.metadata)
+    return [latest.nodeid, Status[status]]
+  }
+
   return (
     <div className="card">
       <div className="card__header">Tests</div>
@@ -174,7 +210,9 @@ export function TestTable({ reports, metadata, onFilterChange }: Props) {
         headers={headers}
         data={sortedTests}
         row={row}
+        mobileRow={mobileRow}
         getKey={item => item.reports[item.reports.length - 1].database_key}
+        filterStrings={filterStrings}
         onFilterChange={onFilterChange}
       />
     </div>

--- a/src/hypofuzz/frontend/src/pages/CollectionStatus.tsx
+++ b/src/hypofuzz/frontend/src/pages/CollectionStatus.tsx
@@ -53,13 +53,11 @@ export function CollectionStatusPage() {
     {
       content: "Test",
       sortKey: (item: CollectionResult) => item.node_id,
-      filterable: true,
     },
     {
       content: "Status",
       sortKey: (item: CollectionResult) =>
         statusOrder[item.status as keyof typeof statusOrder],
-      filterable: true,
       align: "center",
     },
   ]
@@ -93,6 +91,7 @@ export function CollectionStatusPage() {
         data={sortedResults}
         row={row}
         getKey={item => item.database_key}
+        filterStrings={item => [item.node_id, item.status]}
       />
     </div>
   )

--- a/src/hypofuzz/frontend/src/styles.scss
+++ b/src/hypofuzz/frontend/src/styles.scss
@@ -40,6 +40,48 @@ select {
         width: 100%;
     }
 
+    &__mobile-row {
+        background: white;
+        padding: 1rem;
+        margin-bottom: 1rem;
+        border-radius: 8px;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+
+        &__header {
+            display: flex;
+            align-items: center;
+            gap: 0.6rem;
+            margin-bottom: 1rem;
+            flex-wrap: wrap;
+
+            // allow test link to shrink more than the pill. prevents the pill
+            // overflowing to next line
+            .test__link {
+                flex: 1;
+            }
+        }
+
+        &__statistics {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.75rem;
+        }
+    }
+
+    &__inline-statistic {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        color: #666;
+        padding: 0.5rem;
+        background: #f8f9fa;
+        border-radius: 4px;
+
+        &__value {
+            font-variant-numeric: tabular-nums;
+        }
+    }
+
     &__filter {
         margin-bottom: 5px;
         width: min(100%, 20rem);
@@ -134,6 +176,7 @@ select {
         display: flex;
 
         &__icon {
+            text-align: center;
             font-size: 1.1em;
             color: #666;
             width: 20px;


### PR DESCRIPTION
Also remove the right-side list of all tests in the graph, which is probably better served by the ability to search for tests? Node ids are usually too long for listing them on the sidebar to be reasonable ui.