### PR TITLE
Send dashboard state incrementally

### DIFF
--- a/src/hypofuzz/dashboard/dashboard.py
+++ b/src/hypofuzz/dashboard/dashboard.py
@@ -4,8 +4,9 @@ import abc
 import json
 import math
 from collections import defaultdict
+from enum import IntEnum
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 import black
 import trio
@@ -41,6 +42,16 @@ COLLECTION_RESULT: Optional[CollectionResult] = None
 websockets: set["HypofuzzWebsocket"] = set()
 
 
+class DashboardEventType(IntEnum):
+    # minimize header frame overhead with a shared IntEnum definition between
+    # python and ts.
+    ADD_TESTS = 1
+    ADD_REPORTS = 2
+    ADD_ROLLING_OBSERVATIONS = 3
+    ADD_CORPUS_OBSERVATIONS = 4
+    SET_FAILURE = 5
+
+
 def test_for_websocket(test: Test) -> dict[str, Any]:
     # Limit to 1000 reports per test. If we're over 1000 total reports, sample
     # evenly from each worker.
@@ -58,8 +69,7 @@ def test_for_websocket(test: Test) -> dict[str, Any]:
     # (4) sample more tightly earlier on and less tightly later on, since there is
     #     more behavior and fingerprint growth early. This is especially important
     #     for log x axis graphs, which show more early intervals than late intervals
-    count_reports = sum(len(reports) for reports in test.reports_by_worker.values())
-    step = (count_reports // 1000) + 1
+    step = (len(test.linear_reports) // 1000) + 1
     return {
         "database_key": test.database_key,
         "nodeid": test.nodeid,
@@ -123,31 +133,72 @@ class HypofuzzWebsocket(abc.ABC):
         pass
 
     @abc.abstractmethod
-    async def on_event(self, header: dict[str, Any], data: Any) -> None:
+    async def on_event(
+        self, event_type: Literal["save", "delete"], key: DatabaseEventKey, value: Any
+    ) -> None:
         pass
 
 
 class OverviewWebsocket(HypofuzzWebsocket):
     async def initial(self, tests: dict[str, Test]) -> None:
-        tests = {nodeid: test_for_websocket(test) for nodeid, test in tests.items()}
-        await self.send_event({"type": "initial", "initial_type": "tests"}, tests)
-        # don't send observations event, overview page doesn't use them
+        # should we be passing in some global nursery here instead? I think this
+        # will block any callers until all send_event tasks complete, right?
+        # which we don't necessarily care about (though it's less important than
+        # sending all the events here in parallel).
+        async with trio.open_nursery() as nursery:
+            # we start by sending all tests, which is the most important
+            # thing for the user to see first.
+            tests_data = {
+                "tests": [
+                    {
+                        "database_key": test.database_key,
+                        "nodeid": test.nodeid,
+                        "failure": test.failure,
+                    }
+                    for test in tests.values()
+                ]
+            }
+            nursery.start_soon(
+                self.send_event,
+                {"type": DashboardEventType.ADD_TESTS},
+                tests_data,
+            )
 
-    async def on_event(self, header: dict[str, Any], data: Any) -> None:
-        if header["type"] == "save":
-            if header["key"] not in [
-                DatabaseEventKey.REPORT,
-                DatabaseEventKey.FAILURE,
-            ]:
-                return
-            if header["key"] is DatabaseEventKey.REPORT:
-                assert isinstance(data, Report)
-                data = {
-                    "nodeid": data.nodeid,
-                    "worker_uuid": data.worker_uuid,
-                    "report": report_for_websocket(data),
+            # Then we send the reports for each test.
+            for test in tests.values():
+                for worker_uuid, reports in test.reports_by_worker.items():
+                    report_data = {
+                        "nodeid": test.nodeid,
+                        "worker_uuid": worker_uuid,
+                        "reports": [report_for_websocket(report) for report in reports],
+                    }
+                    nursery.start_soon(
+                        self.send_event,
+                        {"type": DashboardEventType.ADD_REPORTS},
+                        report_data,
+                    )
+
+    async def on_event(
+        self, event_type: Literal["save", "delete"], key: DatabaseEventKey, value: Any
+    ) -> None:
+        if event_type == "save":
+            # don't send observations events, the overview page doesn't use
+            # observations.
+            if key is DatabaseEventKey.REPORT:
+                assert isinstance(value, Report)
+                data: Any = {
+                    "nodeid": value.nodeid,
+                    "worker_uuid": value.worker_uuid,
+                    "reports": [report_for_websocket(value)],
                 }
-            await self.send_event(header, data)
+                await self.send_event({"type": DashboardEventType.ADD_REPORTS}, data)
+            if key is DatabaseEventKey.FAILURE:
+                assert isinstance(value, Observation)
+                data = {
+                    "nodeid": value.property,
+                    "failure": value,
+                }
+                await self.send_event({"type": DashboardEventType.SET_FAILURE}, data)
 
 
 class TestWebsocket(HypofuzzWebsocket):
@@ -157,49 +208,91 @@ class TestWebsocket(HypofuzzWebsocket):
 
     async def initial(self, tests: dict[str, Test]) -> None:
         test = tests[self.nodeid]
-        # split initial event in two pieces: test (without observations), and observations.
-        tests = {self.nodeid: test_for_websocket(test)}
-        observations = {
-            self.nodeid: {
-                "rolling": test.rolling_observations,
-                "corpus": test.corpus_observations,
+        async with trio.open_nursery() as nursery:
+            # send the test first
+            test_data = {
+                "database_key": test.database_key,
+                "nodeid": test.nodeid,
+                "failure": test.failure,
             }
-        }
-        await self.send_event({"type": "initial", "initial_type": "tests"}, tests)
-        await self.send_event(
-            {"type": "initial", "initial_type": "observations"}, observations
-        )
+            nursery.start_soon(
+                self.send_event,
+                {"type": DashboardEventType.ADD_TESTS},
+                [test_data],
+            )
 
-    async def on_event(self, header: dict[str, Any], data: Any) -> None:
-        if header["type"] == "save":
-            if header["key"] is DatabaseEventKey.REPORT:
-                assert isinstance(data, Report)
-                nodeid = data.nodeid
-                data = {
-                    "nodeid": nodeid,
-                    "worker_uuid": data.worker_uuid,
-                    "report": report_for_websocket(data),
+            # then its reports
+            for worker_uuid, reports in test.reports_by_worker.items():
+                report_data = {
+                    "nodeid": test.nodeid,
+                    "worker_uuid": worker_uuid,
+                    "reports": [report_for_websocket(report) for report in reports],
                 }
-            elif header["key"] in [
-                DatabaseEventKey.FAILURE,
+                nursery.start_soon(
+                    self.send_event,
+                    {"type": DashboardEventType.ADD_REPORTS},
+                    report_data,
+                )
+
+            nursery.start_soon(
+                self.send_event,
+                {"type": DashboardEventType.ADD_ROLLING_OBSERVATIONS},
+                {"nodeid": self.nodeid, "observations": test.rolling_observations},
+            )
+            nursery.start_soon(
+                self.send_event,
+                {"type": DashboardEventType.ADD_CORPUS_OBSERVATIONS},
+                {"nodeid": self.nodeid, "observations": test.corpus_observations},
+            )
+
+    async def on_event(
+        self, event_type: Literal["save", "delete"], key: DatabaseEventKey, value: Any
+    ) -> None:
+        if event_type == "save":
+            if key is DatabaseEventKey.REPORT:
+                assert isinstance(value, Report)
+                nodeid = value.nodeid
+                value = {
+                    "nodeid": nodeid,
+                    "worker_uuid": value.worker_uuid,
+                    "reports": [report_for_websocket(value)],
+                }
+                dashboard_event = DashboardEventType.ADD_REPORTS
+            elif key is DatabaseEventKey.FAILURE:
+                assert isinstance(value, Observation)
+                nodeid = value.property
+                dashboard_event = DashboardEventType.SET_FAILURE
+                value = {
+                    "nodeid": nodeid,
+                    "failure": value,
+                }
+            elif key in [
                 DatabaseEventKey.ROLLING_OBSERVATION,
                 DatabaseEventKey.CORPUS_OBSERVATION,
             ]:
-                assert isinstance(data, Observation)
-                nodeid = data.property
-            elif header["key"] in [
-                DatabaseEventKey.FAILURE_OBSERVATION,
-                DatabaseEventKey.CORPUS,
-            ]:
-                return
+                assert isinstance(value, Observation)
+                nodeid = value.property
+                dashboard_event = {
+                    DatabaseEventKey.ROLLING_OBSERVATION: DashboardEventType.ADD_ROLLING_OBSERVATIONS,
+                    DatabaseEventKey.CORPUS_OBSERVATION: DashboardEventType.ADD_CORPUS_OBSERVATIONS,
+                }[key]
+                value = {
+                    "nodeid": nodeid,
+                    "observations": [value],
+                }
             else:
-                raise NotImplementedError(f"unhandled event {header}")
+                # assert so I don't forget a case
+                assert key in [
+                    DatabaseEventKey.FAILURE_OBSERVATION,
+                    DatabaseEventKey.CORPUS,
+                ], key
+                return
 
             # only broadcast event for this nodeid
             if nodeid != self.nodeid:
                 return
 
-            await self.send_event(header, data)
+            await self.send_event({"type": dashboard_event}, value)
 
 
 async def websocket(websocket: WebSocket) -> None:
@@ -226,10 +319,12 @@ async def websocket(websocket: WebSocket) -> None:
         websockets.remove(websocket)
 
 
-async def broadcast_event(header: dict[str, Any], data: Any) -> None:
+async def broadcast_event(
+    event_type: Literal["save", "delete"], key: DatabaseEventKey, value: Any
+) -> None:
     # avoid websocket disconnecting during iteration and causing a RuntimeError
     for websocket in websockets.copy():
-        await websocket.on_event(header, data)
+        await websocket.on_event(event_type, key, value)
 
 
 def try_format(code: str) -> str:
@@ -391,7 +486,7 @@ async def handle_event(receive_channel: MemoryReceiveChannel[ListenerEventT]) ->
                 continue
             TESTS[event.value.property].corpus_observations.append(event.value)
 
-        await broadcast_event({"type": event.type, "key": event.key}, event.value)
+        await broadcast_event(event.type, event.key, event.value)
 
 
 async def run_dashboard(port: int, host: str) -> None:
@@ -425,12 +520,9 @@ async def run_dashboard(port: int, host: str) -> None:
         key = fuzz_target.database_key
 
         rolling_observations = list(db.fetch_observations(key))
-        # TODO this runs choice_to_bytes in fetch_corpus and then choice_from_bytes
-        # in fetch_corpus_observation. We should add a as_bytes param to fetch_corpus
-        # for performance
         corpus_observations = [
             db.fetch_corpus_observation(key, choices)
-            for choices in db.fetch_corpus(key)
+            for choices in db.fetch_corpus(key, as_bytes=True)
         ]
         corpus_observations = [
             observation
@@ -461,7 +553,11 @@ async def run_dashboard(port: int, host: str) -> None:
             nodeid=fuzz_target.nodeid,
             rolling_observations=rolling_observations,
             corpus_observations=corpus_observations,
-            reports_by_worker=reports_by_worker,
+            # we're abusing this argument, post-init the reports have type
+            # ReportWithDiff, but at pre-init they have type Report. We should
+            # split this into two attributes, one for Report which we pass at init
+            # and one for ReportWithDiff which is set/stored post-init.
+            reports_by_worker=reports_by_worker,  # type: ignore
             # TODO: refactor Test, and our frontend, to support multiple failures.
             failure=next(iter(failure_observations.values()), None),
         )

--- a/src/hypofuzz/frontend/src/App.tsx
+++ b/src/hypofuzz/frontend/src/App.tsx
@@ -13,22 +13,17 @@ export function App() {
 
   return (
     <Router>
-      <Routes>
-        <Route element={<Layout />}>
-          <Route
-            path="/"
-            element={
-              <DataProvider>
-                <TestsPage />
-              </DataProvider>
-            }
-          />
-          <Route path="/patches" element={<PatchesPage />} />
-          <Route path="/collected" element={<CollectionStatusPage />} />
-          <Route path="/tests/:nodeid" element={<TestPage />} />
-          <Route path="*" element={<NotFoundPage />} />
-        </Route>
-      </Routes>
+      <DataProvider>
+        <Routes>
+          <Route element={<Layout />}>
+            <Route path="/" element={<TestsPage />} />
+            <Route path="/patches" element={<PatchesPage />} />
+            <Route path="/collected" element={<CollectionStatusPage />} />
+            <Route path="/tests/:nodeid" element={<TestPage />} />
+            <Route path="*" element={<NotFoundPage />} />
+          </Route>
+        </Routes>
+      </DataProvider>
     </Router>
   )
 }

--- a/src/hypofuzz/frontend/src/components/CoverageGraph.tsx
+++ b/src/hypofuzz/frontend/src/components/CoverageGraph.tsx
@@ -416,25 +416,34 @@ export function CoverageGraph({ tests, filterString = "" }: Props) {
 
   const reports = useMemo(() => {
     return new Map(
-      Array.from(tests.entries()).map(([nodeid, test]) => {
-        // zip up linear_status_counts, linear_elapsed_time, and linear_reports.
-        const linearStatusCounts = test.linear_status_counts(null)
-        const linearElapsedTime = test.linear_elapsed_time(null)
-        const reports: GraphReport[] = []
-        for (let i = 0; i < linearStatusCounts.length; i++) {
-          const report = test.linear_reports[i]
-          reports.push({
-            nodeid: nodeid,
-            linear_status_counts: linearStatusCounts[i],
-            linear_elapsed_time: linearElapsedTime[i],
-            behaviors: report.behaviors,
-            fingerprints: report.fingerprints,
-            ninputs: report.ninputs,
-            elapsed_time: report.elapsed_time,
-          })
-        }
-        return [nodeid, reports]
-      }),
+      Array.from(tests.entries())
+        // deterministic line color ordering, regardless of insertion order (which might vary
+        // based on websocket arrival order)
+        //
+        // we may also want a deterministic mapping of hash(nodeid) -> color, so the color is stable
+        // even across pages (overview vs individual test) or after a new test is added? But maybe we
+        // *don't* want this. I'm not sure which is better ux. A graph with only one line and having
+        // a non-blue color is weird.
+        .sortKey(([nodeid, test]) => nodeid)
+        .map(([nodeid, test]) => {
+          // zip up linear_status_counts, linear_elapsed_time, and linear_reports.
+          const linearStatusCounts = test.linear_status_counts(null)
+          const linearElapsedTime = test.linear_elapsed_time(null)
+          const reports: GraphReport[] = []
+          for (let i = 0; i < linearStatusCounts.length; i++) {
+            const report = test.linear_reports[i]
+            reports.push({
+              nodeid: nodeid,
+              linear_status_counts: linearStatusCounts[i],
+              linear_elapsed_time: linearElapsedTime[i],
+              behaviors: report.behaviors,
+              fingerprints: report.fingerprints,
+              ninputs: report.ninputs,
+              elapsed_time: report.elapsed_time,
+            })
+          }
+          return [nodeid, reports]
+        }),
     )
   }, [tests])
 

--- a/src/hypofuzz/frontend/src/components/TestTable.tsx
+++ b/src/hypofuzz/frontend/src/components/TestTable.tsx
@@ -189,7 +189,12 @@ export function TestTable({ tests, onFilterChange }: Props) {
         data={sortedTests}
         row={row}
         mobileRow={mobileRow}
-        getKey={test => test.database_key}
+        // we'd like to use
+        //   getKey={test => test.database_key}
+        // here, but test is not guaranteed to have a databse_key set (if e.g.
+        // ADD_REPORTS arrives before ADD_TESTS), and I'm more worried about
+        // accidentally choosing an overlapping fallback key than trying to squeeze
+        // out performance here.
         filterStrings={filterStrings}
         onFilterChange={onFilterChange}
       />

--- a/src/hypofuzz/frontend/src/context/DataProvider.tsx
+++ b/src/hypofuzz/frontend/src/context/DataProvider.tsx
@@ -1,36 +1,143 @@
-import React, { createContext, useContext, useEffect, useState, useRef } from "react"
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useReducer,
+  useState,
+} from "react"
 import { Observation, Report, Test } from "../types/dashboard"
 
 interface DataContextType {
   tests: Map<string, Test>
   socket: WebSocket | null
+  doLoadData: (nodeid: string | null) => void
 }
 
 const DataContext = createContext<DataContextType | null>(null)
 
 interface DataProviderProps {
   children: React.ReactNode
-  nodeid?: string
 }
 
-export function DataProvider({ children, nodeid }: DataProviderProps) {
+enum DashboardEventType {
+  ADD_TESTS = 1,
+  ADD_REPORTS = 2,
+  ADD_ROLLING_OBSERVATIONS = 3,
+  ADD_CORPUS_OBSERVATIONS = 4,
+  SET_FAILURE = 5,
+}
+
+type TestsAction =
+  | {
+      type: DashboardEventType.ADD_TESTS
+      tests: {
+        database_key: string
+        nodeid: string
+        failure: Observation | null
+      }[]
+    }
+  | {
+      type: DashboardEventType.ADD_REPORTS
+      nodeid: string
+      worker_uuid: string
+      reports: Report[]
+    }
+  | { type: DashboardEventType.SET_FAILURE; failure: Observation }
+  | {
+      type: DashboardEventType.ADD_ROLLING_OBSERVATIONS
+      nodeid: string
+      observations: Observation[]
+    }
+  | {
+      type: DashboardEventType.ADD_CORPUS_OBSERVATIONS
+      nodeid: string
+      observations: Observation[]
+    }
+
+function testsReducer(
+  state: Map<string, Test>,
+  action: TestsAction,
+): Map<string, Test> {
+  const newState = new Map(state)
+
+  function getOrCreateTest(nodeid: string): Test {
+    if (newState.has(nodeid)) {
+      return newState.get(nodeid)!
+    } else {
+      const test = new Test(null, nodeid, [], [], null, new Map())
+      newState.set(test.nodeid, test)
+      return test
+    }
+  }
+
+  switch (action.type) {
+    case DashboardEventType.ADD_TESTS: {
+      const { tests } = action
+      for (const { database_key, nodeid, failure } of tests) {
+        const test = getOrCreateTest(nodeid)
+        test.database_key = database_key
+        test.failure = failure ? Observation.fromJson(failure) : null
+      }
+      return newState
+    }
+
+    case DashboardEventType.ADD_REPORTS: {
+      const { nodeid, worker_uuid, reports } = action
+      const test = getOrCreateTest(nodeid)
+      for (const report of reports) {
+        test.add_report(worker_uuid, report)
+      }
+      return newState
+    }
+
+    case DashboardEventType.SET_FAILURE: {
+      const { failure } = action
+      const test = getOrCreateTest(failure.property)
+      test.failure = failure
+      return newState
+    }
+
+    case DashboardEventType.ADD_ROLLING_OBSERVATIONS: {
+      const { nodeid, observations } = action
+      const test = getOrCreateTest(nodeid)
+      test.rolling_observations.push(...observations)
+      // keep only the most recent 300 rolling observations, by run_start
+      //
+      // this is a good candidate for a proper nlogn SortedList
+      test.rolling_observations = test.rolling_observations
+        .sortKey(observation => observation.run_start)
+        .slice(-300)
+      return newState
+    }
+
+    case DashboardEventType.ADD_CORPUS_OBSERVATIONS: {
+      const { nodeid, observations } = action
+      const test = getOrCreateTest(nodeid)
+      test.corpus_observations.push(...observations)
+      return newState
+    }
+
+    default:
+      throw new Error("non-exhaustive switch in testsReducer")
+  }
+}
+
+export function DataProvider({ children }: DataProviderProps) {
   const [socket, setSocket] = useState<WebSocket | null>(null)
-  const [tests, setTests] = useState<Map<string, Test>>(new Map())
-  const [isLoading, setIsLoading] = useState(true)
-  const testsRef = useRef(tests)
+  const [tests, dispatch] = useReducer(testsReducer, new Map<string, Test>())
+  const [loadData, setLoadData] = useState(false)
+  const [nodeid, setNodeid] = useState<string | null>(null)
 
-  // we want access to the latest value of `tests` inside the "save" event. React only
-  // updates the value of `tests` when the component re-renders, which I think is only
-  // when the useEffect triggers? so never, because we only load once per page.
-  //
-  // Instead, hold a ref handle to the current tests so it's always up to date.
-  //
-  // there's probably a better way to do this...
-  useEffect(() => {
-    testsRef.current = tests
-  }, [tests])
+  const doLoadData = (nodeid: string | null) => {
+    setLoadData(true)
+    setNodeid(nodeid)
+  }
 
   useEffect(() => {
+    if (!loadData) {
+      return
+    }
+
     // load data from local dashboard state json files iff the appropriate env var was set
     // during building.
     if (import.meta.env.VITE_USE_DASHBOARD_STATE === "1") {
@@ -38,11 +145,31 @@ export function DataProvider({ children, nodeid }: DataProviderProps) {
         .then(response => response.text())
         .then(text => JSON.parse(text) as Record<string, any>)
         .then(data => {
-          const tests = new Map(
-            Object.entries(data).map(([nodeid, data]) => [nodeid, Test.fromJson(data)]),
-          )
-          setTests(tests)
-          setIsLoading(false)
+          Object.entries(data).forEach(([nodeid, testData]) => {
+            dispatch({
+              type: DashboardEventType.ADD_TESTS,
+              tests: [
+                {
+                  database_key: testData.database_key,
+                  nodeid: nodeid,
+                  failure: testData.failure,
+                },
+              ],
+            })
+
+            for (const [worker_uuid, reports] of Object.entries(
+              testData.reports_by_worker,
+            )) {
+              dispatch({
+                type: DashboardEventType.ADD_REPORTS,
+                nodeid: nodeid,
+                worker_uuid: worker_uuid,
+                reports: (reports as any[]).map(report =>
+                  Report.fromJson(worker_uuid, report),
+                ),
+              })
+            }
+          })
         })
 
       // json.parse is sync (blocks ui) and expensive. Push it to a background worker to make it async.
@@ -63,16 +190,19 @@ export function DataProvider({ children, nodeid }: DataProviderProps) {
             },
           )
         })
-        .then(observationsData => {
-          for (const [test_id, testObservations] of Object.entries(observationsData)) {
-            const test = testsRef.current.get(test_id)!
-            test.rolling_observations = testObservations.rolling.map(
-              Observation.fromJson,
-            )
-            test.corpus_observations = testObservations.corpus.map(Observation.fromJson)
-            test.observations_loaded = true
+        .then(data => {
+          for (const [nodeid, test] of Object.entries(data)) {
+            dispatch({
+              type: DashboardEventType.ADD_ROLLING_OBSERVATIONS,
+              nodeid: nodeid,
+              observations: test.rolling.map(Observation.fromJson),
+            })
+            dispatch({
+              type: DashboardEventType.ADD_CORPUS_OBSERVATIONS,
+              nodeid: nodeid,
+              observations: test.corpus.map(Observation.fromJson),
+            })
           }
-          setTests(new Map(testsRef.current))
         })
 
       return () => worker.terminate()
@@ -96,91 +226,55 @@ export function DataProvider({ children, nodeid }: DataProviderProps) {
       let data = event.data.slice(pipeIndex + 1)
       header = JSON.parse(header)
 
-      switch (header.type) {
-        case "initial":
-          switch (header.initial_type) {
-            case "tests": {
-              data = JSON.parse(data)
-              setTests(
-                new Map(
-                  Object.entries(data).map(([nodeid, data]) => [
-                    nodeid,
-                    Test.fromJson(data),
-                  ]),
-                ),
-              )
-              setIsLoading(false)
-              break
-            }
-            case "observations": {
-              data = JSON.parse(data)
-              for (const [test_id, observationsData] of Object.entries(data)) {
-                // this relies on initial_type == "tests" being parsed first, but I don't think
-                // this is guaranteed in async land. need to refactor each initial_type to create an
-                // empty test and set its attributes appropriately.
-                const test = testsRef.current.get(test_id)!
-                test.rolling_observations = (observationsData as any).rolling.map(
-                  Observation.fromJson,
-                )
-                test.corpus_observations = (observationsData as any).corpus.map(
-                  Observation.fromJson,
-                )
-                test.observations_loaded = true
-                setTests(new Map(testsRef.current))
-              }
-              break
-            }
-          }
+      switch (Number(header.type)) {
+        case DashboardEventType.ADD_TESTS: {
+          data = JSON.parse(data)
+          dispatch({
+            type: DashboardEventType.ADD_TESTS,
+            tests: data.tests.map((test: any) => ({
+              database_key: test.database_key,
+              nodeid: test.nodeid,
+              failure: test.failure,
+            })),
+          })
           break
-        case "save":
-          // this is a differential message. depending on the type of the event, we'll do
-          // something to the appropriate attribute on Test.
-          switch (header.key) {
-            case "report": {
-              data = JSON.parse(data)
-              const report = Report.fromJson(data.report)
-              const test = testsRef.current.get(data.nodeid)!
-              test.add_report(data.worker_uuid, report)
-              // update react state to trigger a re-render on outside components that have a
-              // useEffect dependency on `tests`
-              setTests(new Map(testsRef.current))
-              break
-            }
-            case "failure": {
-              // observability reports use e.g. Infinity, which is invalid in standard json
-              // but valid in json5.
-              data = JSON.parse(data)
-              const failure = Observation.fromJson(data)
-              const test = testsRef.current.get(failure.property)!
-              test.failure = failure
-              // trigger react re-render
-              setTests(new Map(testsRef.current))
-              break
-            }
-            case "rolling_observation": {
-              data = JSON.parse(data)
-              const observation = Observation.fromJson(data)
-              const test = testsRef.current.get(observation.property)!
-              test.rolling_observations.push(observation)
-              // keep only the most recent 300 rolling observations, by run_start
-              //
-              // this is a good candidate for a proper nlogn SortedList
-              test.rolling_observations = test.rolling_observations
-                .sortKey(observation => observation.run_start)
-                .slice(-300)
-              setTests(new Map(testsRef.current))
-              break
-            }
-            case "corpus_observation": {
-              data = JSON.parse(data)
-              const observation = Observation.fromJson(data)
-              const test = testsRef.current.get(observation.property)!
-              test.corpus_observations.push(observation)
-              setTests(new Map(testsRef.current))
-              break
-            }
-          }
+        }
+
+        case DashboardEventType.ADD_REPORTS: {
+          data = JSON.parse(data)
+          dispatch({
+            type: DashboardEventType.ADD_REPORTS,
+            nodeid: data.nodeid,
+            worker_uuid: data.worker_uuid,
+            reports: (data.reports as any[]).map(report =>
+              Report.fromJson(data.worker_uuid, report),
+            ),
+          })
           break
+        }
+
+        case DashboardEventType.ADD_CORPUS_OBSERVATIONS: {
+          data = JSON.parse(data)
+          dispatch({
+            type: DashboardEventType.ADD_CORPUS_OBSERVATIONS,
+            nodeid: data.nodeid,
+            observations: data.observations.map(Observation.fromJson),
+          })
+          break
+        }
+
+        case DashboardEventType.ADD_ROLLING_OBSERVATIONS: {
+          data = JSON.parse(data)
+          dispatch({
+            type: DashboardEventType.ADD_ROLLING_OBSERVATIONS,
+            nodeid: data.nodeid,
+            observations: data.observations.map(Observation.fromJson),
+          })
+          break
+        }
+
+        default:
+          throw new Error(`Unknown event type: ${header.type}`)
       }
     }
 
@@ -189,21 +283,25 @@ export function DataProvider({ children, nodeid }: DataProviderProps) {
     return () => {
       ws.close()
     }
-  }, [nodeid])
-
-  if (isLoading) {
-    return null
-  }
+    // a single DataProvider is created for the entire lifetime of a tab. We want to re-load
+    // the provided data whenever we change the nodeid (e.g. going from overview to a specific
+    // test page) or we go from a page which doesn't want data (because it didn't call useData)
+    // to one that does.
+  }, [nodeid, loadData])
 
   return (
-    <DataContext.Provider value={{ tests, socket }}>{children}</DataContext.Provider>
+    <DataContext.Provider value={{ tests, socket, doLoadData }}>
+      {children}
+    </DataContext.Provider>
   )
 }
 
-export function useData() {
+export function useData(nodeid: string | null = null) {
   const context = useContext(DataContext)
   if (!context) {
     throw new Error("useData must be used within a DataProvider")
   }
+
+  context.doLoadData(nodeid)
   return context
 }

--- a/src/hypofuzz/frontend/src/pages/Test.tsx
+++ b/src/hypofuzz/frontend/src/pages/Test.tsx
@@ -1,6 +1,6 @@
 import { useParams, Link } from "react-router-dom"
 import { CoverageGraph } from "../components/CoverageGraph"
-import { useData, DataProvider } from "../context/DataProvider"
+import { useData } from "../context/DataProvider"
 import { getTestStats } from "../utils/testStats"
 import { Table } from "../components/Table"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
@@ -23,17 +23,7 @@ hljs.registerLanguage("python", python)
 
 export function TestPage() {
   const { nodeid } = useParams<{ nodeid: string }>()
-
-  return (
-    <DataProvider nodeid={nodeid}>
-      <_TestPage />
-    </DataProvider>
-  )
-}
-
-function _TestPage() {
-  const { nodeid } = useParams<{ nodeid: string }>()
-  const { tests } = useData()
+  const { tests } = useData(nodeid)
 
   if (!nodeid || !tests.has(nodeid)) {
     return <div>Test not found</div>

--- a/src/hypofuzz/frontend/src/tyche/Tyche.tsx
+++ b/src/hypofuzz/frontend/src/tyche/Tyche.tsx
@@ -24,14 +24,6 @@ export function Tyche({ test }: { test: Test }) {
     "covering",
   )
 
-  if (!test.observations_loaded) {
-    return (
-      <div className="card">
-        <div className="card__header">Loading observations...</div>
-      </div>
-    )
-  }
-
   const observations =
     observationType === "rolling"
       ? // newest first for rolling observations

--- a/src/hypofuzz/utils.py
+++ b/src/hypofuzz/utils.py
@@ -1,6 +1,8 @@
+import heapq
 import math
 import threading
-from typing import Any, Generic, TypeVar
+from collections.abc import Sequence
+from typing import Any, Callable, Generic, TypeVar
 
 T = TypeVar("T")
 
@@ -51,3 +53,30 @@ class Value(Generic[T]):
 
 def lerp(a: float, b: float, t: float) -> float:
     return (1 - t) * a + t * b
+
+
+def k_way_merge(
+    lists: Sequence[Sequence[T]], key: Callable[[T], Any] = lambda x: x
+) -> list[T]:
+    # merges k sorted lists in O(nlg(k)) time, where n is the total number of
+    # elements.
+    #
+    # NOTE: this implementation is *not* a stable sort, since the heap key
+    #   (key(l[0]), i, 0)
+    # falls back to i when key(l[0]) is equal.
+    result: list[T] = []
+    heap: list[tuple[Any, int, int]] = []
+    assert all(len(l) > 0 for l in lists)
+    for i, l in enumerate(lists):
+        heapq.heappush(heap, (key(l[0]), i, 0))
+
+    while heap:
+        _key, list_i, value_i = heapq.heappop(heap)
+        val = lists[list_i][value_i]
+        result.append(val)
+
+        if value_i + 1 < len(lists[list_i]):
+            next_value = lists[list_i][value_i + 1]
+            heapq.heappush(heap, (key(next_value), list_i, value_i + 1))
+
+    return result

--- a/tests/test_linearize.py
+++ b/tests/test_linearize.py
@@ -37,6 +37,33 @@ def workers(*, uuid):
 _shared_tests = [(b"database_key_" + str(i).encode(), f"nodeid_{i}") for i in range(10)]
 
 
+def report_inline(
+    *,
+    database_key=b"inline-database_key",
+    nodeid="inline-nodeid",
+    elapsed_time=0.0,
+    timestamp=0.0,
+    worker_uuid="inline-worker_uuid",
+    status_counts=None,
+    behaviors=0,
+    fingerprints=0,
+    since_new_branch=0,
+    phase=Phase.GENERATE,
+):
+    return Report(
+        database_key=database_key,
+        nodeid=nodeid,
+        elapsed_time=elapsed_time,
+        timestamp=timestamp,
+        worker_uuid=worker_uuid,
+        status_counts=StatusCounts() if status_counts is None else status_counts,
+        behaviors=behaviors,
+        fingerprints=fingerprints,
+        since_new_branch=since_new_branch,
+        phase=phase,
+    )
+
+
 @st.composite
 def reports(
     draw, *, count_workers: Optional[int] = None, overlap: bool = False
@@ -65,10 +92,10 @@ def reports(
     for uuid, (start_time, end_time) in zip(uuids, intervals):
         # reports from the same worker always have monotonically increasing
         # coverage, timestamps, and elapsed_time
-        # (TODO: we don't actually rely on timestamps being ordered. But our logic
-        # for unordered reports isn't correct yet either (we drop them, when we
-        # should correctly recompute/reinsert). Drop the .map(sorted) for timestamps
-        # when we implement this correctly.
+        # (TODO: we shouldn't actually rely on timestamps being ordered. But
+        # test_single_worker fails without it. This might be a real failure
+        # or it might be an acceptable edge case. Drop the .map(sorted) for timestamps
+        # when we investigte and fix it / figure out which it is.
         ninputs = draw(st.lists(st.integers(min_value=0)).map(sorted))
         timestamps = draw(
             st.lists(
@@ -129,10 +156,8 @@ def assert_reports_almost_equal(reports1, reports2):
                 assert v1 == v2
 
 
-def _test_for_reports(reports) -> Test:
+def _test_for_reports(reports, *, database_key: bytes = b"", nodeid: str = "") -> Test:
     reports_by_worker = defaultdict(list)
-    database_key = b""
-    nodeid = ""
     for report in sorted(reports, key=lambda r: r.elapsed_time):
         reports_by_worker[report.worker_uuid].append(report)
         database_key = report.database_key
@@ -182,12 +207,7 @@ def test_linearize_decomposes_with_addition(data):
     # nodeid in _test_for_reports, since there are no reports to draw the nodeid
     # from).
     assume(len(reports_) > 1)
-    # the decomposition property is only actually true if we add reports in a sorted
-    # order. This may not happen in practice, because e.g. reports from workers may
-    # arrive out of order.
-    # (e: this may no longer be true now that we correctly drop/handle out-of-order
-    # reports in Test.add_report?)
-    reports_ = sorted(reports_, key=lambda r: r.timestamp)
+
     i = data.draw(st.integers(1, len(reports_) - 1))
     test1 = _test_for_reports(reports_)
 
@@ -199,3 +219,114 @@ def test_linearize_decomposes_with_addition(data):
     assert test1.linear_status_counts() == test2.linear_status_counts()
     assert test1.linear_elapsed_time() == pytest.approx(test2.linear_elapsed_time())
     assert_reports_almost_equal(test1.linear_reports, test2.linear_reports)
+
+
+@given(reports())
+def test_out_of_order_report_invalidates_cache(reports):
+    assume(len(reports) > 1)
+    test = _test_for_reports(
+        [], database_key=reports[0].database_key, nodeid=reports[0].nodeid
+    )
+    # this is a pretty bad PBT, but asserting the actual property requires
+    # reimplementing the linearization logic for the multi-worker case.
+    for report in reports:
+        test.add_report(report)
+        assert len(test.linear_status_counts()) == len(test.linear_reports)
+        assert len(test.linear_elapsed_time()) == len(test.linear_reports)
+
+    test._check_invariants()
+
+
+def test_out_of_order_report_invalidates_cache_explicit():
+    test = _test_for_reports(
+        [], database_key=b"inline-database_key", nodeid="inline-nodeid"
+    )
+
+    test.add_report(report_inline(elapsed_time=1.0, timestamp=1.0))
+    assert test.linear_elapsed_time() == [1.0]
+
+    test.add_report(report_inline(elapsed_time=0.5, timestamp=0.5))
+    assert test.linear_elapsed_time() == [0.5, 1.0]
+
+    test.add_report(report_inline(elapsed_time=2.0, timestamp=2.0))
+    assert test.linear_elapsed_time() == [0.5, 1.0, 2.0]
+
+    test.add_report(report_inline(elapsed_time=0.75, timestamp=0.75))
+    assert test.linear_elapsed_time() == [0.5, 0.75, 1.0, 2.0]
+
+    test.add_report(report_inline(elapsed_time=0.25, timestamp=0.25))
+    assert test.linear_elapsed_time() == [0.25, 0.5, 0.75, 1.0, 2.0]
+
+    test._check_invariants()
+
+
+def test_multiple_workers_no_overlap_explicit():
+    # multiple workers but no overlap
+    test = _test_for_reports(
+        [], database_key=b"inline-database_key", nodeid="inline-nodeid"
+    )
+    test.add_report(
+        report_inline(elapsed_time=1.0, timestamp=101, worker_uuid="worker_1")
+    )
+    test.add_report(
+        report_inline(elapsed_time=5.0, timestamp=105, worker_uuid="worker_1")
+    )
+
+    test.add_report(
+        report_inline(elapsed_time=1.0, timestamp=201, worker_uuid="worker_2")
+    )
+    test.add_report(
+        report_inline(elapsed_time=5.0, timestamp=205, worker_uuid="worker_2")
+    )
+
+    assert test.linear_elapsed_time() == [1.0, 5.0, 6.0, 10.0]
+
+
+def test_multiple_workers_overlap_explicit():
+    # multiple workers, with overlap
+    test = _test_for_reports(
+        [], database_key=b"inline-database_key", nodeid="inline-nodeid"
+    )
+    test.add_report(
+        report_inline(elapsed_time=1.0, timestamp=101, worker_uuid="worker_1")
+    )
+    assert test.linear_elapsed_time() == [1.0]
+    test.add_report(
+        report_inline(elapsed_time=5.0, timestamp=105, worker_uuid="worker_1")
+    )
+    assert test.linear_elapsed_time() == [1.0, 5.0]
+
+    test.add_report(
+        report_inline(elapsed_time=1.0, timestamp=102, worker_uuid="worker_2")
+    )
+    assert test.linear_elapsed_time() == [1.0, 2.0, 6.0]
+
+    test.add_report(
+        report_inline(elapsed_time=5.0, timestamp=106, worker_uuid="worker_2")
+    )
+    assert test.linear_elapsed_time() == [1.0, 2.0, 6.0, 10.0]
+
+
+def test_desynced_timestamp():
+    # test where the difference in timestamps is different than the difference
+    # in elapsed_time between reports, which tests our timestamp_monotonic
+    # logic
+    test = _test_for_reports(
+        [], database_key=b"inline-database_key", nodeid="inline-nodeid"
+    )
+    test.add_report(
+        report_inline(elapsed_time=1.0, timestamp=101, worker_uuid="worker_1")
+    )
+    test.add_report(
+        report_inline(elapsed_time=5.0, timestamp=103, worker_uuid="worker_1")
+    )
+
+    test.add_report(
+        report_inline(elapsed_time=1.0, timestamp=101.1, worker_uuid="worker_2")
+    )
+    test.add_report(
+        report_inline(elapsed_time=2.0, timestamp=101.5, worker_uuid="worker_2")
+    )
+
+    assert test.linear_elapsed_time() == [1.0, 2.0, 3.0, 7.0]
+    test._check_invariants()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+
+from hypothesis import given, strategies as st
+
+from hypofuzz.utils import k_way_merge
+
+
+@given(st.lists(st.lists(st.integers(), min_size=1).map(sorted)))
+def test_k_way_merge(lists):
+    assert k_way_merge(lists) == sorted(sum(lists, []))
+
+
+@dataclass
+class A:
+    value: int
+
+
+def test_k_way_merge_key():
+    a1 = A(1)
+    a2 = A(2)
+    a3 = A(3)
+    a4 = A(4)
+    a5 = A(5)
+    assert k_way_merge([[a1, a3, a4], [a2, a5]], key=lambda x: x.value) == [
+        a1,
+        a2,
+        a3,
+        a4,
+        a5,
+    ]


### PR DESCRIPTION
This refactors the websocket to send incremental json messages, instead of one big json message. We still batch at some level for performance (e.g. we send all of a worker's reports in a single message) send websocket frames have overhead.

Since we're receiving data asyncly / out of order now, this required correctly implementing the insertion logic for out-of-order reports in `add_report`.