### PR TITLE
Properly send failure deletion events

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,6 +14,6 @@ if [ "$1" = "docs" ]; then
 elif [ "$1" = "dashboard" ]; then
     npm --prefix "$ROOT/src/hypofuzz/frontend" run build
 else
-    echo "Unknown build target $1. Availabletargets: docs, dashboard"
+    echo "Unknown build target $1. Available targets: docs, dashboard"
     exit 1
 fi

--- a/src/hypofuzz/dashboard/dashboard.py
+++ b/src/hypofuzz/dashboard/dashboard.py
@@ -186,7 +186,7 @@ class OverviewWebsocket(HypofuzzWebsocket):
         if event_type == "delete":
             # TODO when we support multiple failures, we'll need to send the
             # specific observation that was deleted here, either via a
-            # DELETE_OBSERVATION or a SET_FAILURES (not the plural)
+            # DELETE_OBSERVATION or a SET_FAILURES (note the plural)
             if key is DatabaseEventKey.FAILURE_OBSERVATION:
                 event = {
                     "type": DashboardEventType.SET_FAILURE,

--- a/src/hypofuzz/dashboard/dashboard.py
+++ b/src/hypofuzz/dashboard/dashboard.py
@@ -519,7 +519,8 @@ async def handle_event(receive_channel: MemoryReceiveChannel[ListenerEventT]) ->
                 # one (unless the database supports value deletion). Re-scan its
                 # failures.
                 test = TESTS_BY_KEY[event.database_key]
-                failure_observations = get_failure_observations(test.database_key_bytes)
+                assert test.database_key_bytes == event.database_key
+                failure_observations = get_failure_observations(event.database_key)
                 if not failure_observations.values():
                     previous_failure = test.failure
                     test.failure = None

--- a/src/hypofuzz/dashboard/models.py
+++ b/src/hypofuzz/dashboard/models.py
@@ -103,7 +103,8 @@ class AddObservationsEvent(TypedDict):
 
 class SetFailureEvent(TypedDict):
     type: Literal[DashboardEventType.SET_FAILURE]
-    failure: DashboardObservation
+    nodeid: str
+    failure: Optional[DashboardObservation]
 
 
 DashboardEventT = Union[

--- a/src/hypofuzz/dashboard/test.py
+++ b/src/hypofuzz/dashboard/test.py
@@ -11,6 +11,7 @@ from hypofuzz.database import (
     Report,
     ReportWithDiff,
     StatusCounts,
+    convert_db_key,
 )
 from hypofuzz.utils import fast_bisect_right, k_way_merge
 
@@ -59,6 +60,10 @@ class Test:
             self.add_report(report)
 
         self._check_invariants()
+
+    @property
+    def database_key_bytes(self) -> bytes:
+        return convert_db_key(self.database_key, to="bytes")
 
     @staticmethod
     def _assert_reports_ordered(

--- a/src/hypofuzz/frontend/src/context/DataProvider.tsx
+++ b/src/hypofuzz/frontend/src/context/DataProvider.tsx
@@ -41,7 +41,11 @@ type TestsAction =
       worker_uuid: string
       reports: Report[]
     }
-  | { type: DashboardEventType.SET_FAILURE; failure: Observation }
+  | {
+      type: DashboardEventType.SET_FAILURE
+      nodeid: string
+      failure: Observation | null
+    }
   | {
       type: DashboardEventType.ADD_OBSERVATIONS
       nodeid: string
@@ -86,8 +90,8 @@ function testsReducer(
     }
 
     case DashboardEventType.SET_FAILURE: {
-      const { failure } = action
-      const test = getOrCreateTest(failure.property)
+      const { nodeid, failure } = action
+      const test = getOrCreateTest(nodeid)
       test.failure = failure
       return newState
     }
@@ -246,6 +250,15 @@ export function DataProvider({ children }: DataProviderProps) {
             nodeid: data.nodeid,
             observation_type: data.observation_type,
             observations: data.observations.map(Observation.fromJson),
+          })
+          break
+        }
+
+        case DashboardEventType.SET_FAILURE: {
+          dispatch({
+            type: DashboardEventType.SET_FAILURE,
+            nodeid: data.nodeid,
+            failure: data.failure ? Observation.fromJson(data.failure) : null,
           })
           break
         }

--- a/src/hypofuzz/interface.py
+++ b/src/hypofuzz/interface.py
@@ -226,7 +226,12 @@ def _get_hypothesis_tests_with_pytest(
         print(f"Exiting because pytest returned exit code {ret}")
         sys.exit(ret)
     elif debug or not collector.fuzz_targets:
+        print("debug:" if debug else "no fuzz targets found:")
         print(out.getvalue())
+        print("The following tests were not collected:")
+        for nodeid, reason in collector.not_collected.items():
+            print(f"{nodeid} (because: {reason})")
+
     return CollectionResult(
         fuzz_targets=collector.fuzz_targets, not_collected=collector.not_collected
     )

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,17 +1,24 @@
 import requests
-from common import BASIC_TEST_CODE, dashboard, fuzz, wait_for, write_test_code
+from common import (
+    BASIC_TEST_CODE,
+    dashboard,
+    fuzz,
+    setup_test_code,
+    wait_for,
+    write_test_code,
+)
 
 
-def test_can_launch_dashboard():
-    test_dir, _db_dir = write_test_code(BASIC_TEST_CODE)
+def test_can_launch_dashboard(tmp_path):
+    test_dir, _db_dir = setup_test_code(tmp_path, BASIC_TEST_CODE)
 
     with dashboard(test_path=test_dir) as dash:
         requests.get(f"http://localhost:{dash.port}", timeout=10).raise_for_status()
         dash.state()
 
 
-def test_fuzzing_fills_dashboard():
-    test_dir, _db_dir = write_test_code(BASIC_TEST_CODE)
+def test_fuzzing_fills_dashboard(tmp_path):
+    test_dir, _db_dir = setup_test_code(tmp_path, BASIC_TEST_CODE)
 
     with dashboard(test_path=test_dir) as dash:
         state = dash.state()
@@ -21,9 +28,64 @@ def test_fuzzing_fills_dashboard():
         assert not state["test_a.py::test"]["reports_by_worker"]
 
         # now launch a fuzzer, and check that it eventually updates the dashboard state
-        with fuzz(n=1, dashboard=False, test_path=test_dir):
+        with fuzz(n=1, test_path=test_dir):
             wait_for(
                 lambda: len(dash.state()["test_a.py::test"]["reports_by_worker"]) > 0,
-                timeout=10,
+                interval=0.25,
+            )
+
+
+def test_dashboard_failure(tmp_path):
+    test_dir, db_dir = setup_test_code(
+        tmp_path,
+        """
+        def maybe_fail():
+            assert False
+
+        @given(st.integers())
+        def test_maybe_fail(n):
+            maybe_fail()
+        """,
+    )
+
+    with dashboard(test_path=test_dir) as dash:
+        assert dash.state()["test_a.py::test_maybe_fail"]["failure"] is None
+        with fuzz(n=1, test_path=test_dir):
+            wait_for(
+                lambda: (
+                    dash.state()["test_a.py::test_maybe_fail"]["failure"] is not None
+                ),
+                interval=0.25,
+            )
+
+    # if we restart the dasbhoard, the failure is still shown
+    with dashboard(test_path=test_dir) as dash:
+        failure = dash.state()["test_a.py::test_maybe_fail"]["failure"]
+        assert failure is not None
+        assert failure["property"] == "test_a.py::test_maybe_fail"
+
+    # and also if we change the code to pass, but don't run the worker again, the
+    # failure is still shown
+    write_test_code(
+        test_dir / "test_a.py",
+        db_dir,
+        """
+        def maybe_fail():
+            assert True
+
+        @given(st.integers())
+        def test_maybe_fail(n):
+            maybe_fail()
+        """,
+    )
+    with dashboard(test_path=test_dir) as dash:
+        failure = dash.state()["test_a.py::test_maybe_fail"]["failure"]
+        assert failure is not None
+        assert failure["property"] == "test_a.py::test_maybe_fail"
+
+        # but if we run the worker again, the failure disappears
+        with fuzz(n=1, test_path=test_dir):
+            wait_for(
+                lambda: (dash.state()["test_a.py::test_maybe_fail"]["failure"] is None),
                 interval=0.25,
             )


### PR DESCRIPTION
I'm pretty happy with this, except again the note that the listener knows that a failure (observation) has been deleted, but not *which* failure. We don't expect there to be many failures, so we just rescan the the failures key for all tests which currently have a failure, and send the diff (tests which used to have a failure and now don't) to the dashboard.