### PR TITLE
Fix corpus eviction under instability

### DIFF
--- a/src/hypofuzz/corpus.py
+++ b/src/hypofuzz/corpus.py
@@ -1,6 +1,6 @@
 """Adaptive fuzzing for property-based tests using Hypothesis."""
 
-from collections import Counter
+from collections import Counter, defaultdict
 from collections.abc import Callable, Iterator, Set
 from random import Random
 from typing import TYPE_CHECKING, Optional, Union
@@ -118,6 +118,14 @@ class Corpus:
         self.fingerprints: dict[Fingerprint, NodesT] = {}
         # How many times have we seen each branch since discovering our latest branch?
         self.behavior_counts: Counter[Behavior] = Counter()
+        # if we have < 100% stability, one choice sequence might correspond
+        # to multiple fingerprints. _count_fingerprints maps choice sequences to
+        # the number of distinct fingerprints for that choice sequence.
+        #
+        # We only evict a choice sequence once it has zero remaining corresponding
+        # fingerprints. The correctness of this refcounting is validated in
+        # _check_invariants.
+        self._count_fingerprints: dict[Choices, int] = defaultdict(int)
         self.interesting_examples: dict[
             InterestingOrigin, tuple[ConjectureResult, Optional[Observation]]
         ] = {}
@@ -133,10 +141,6 @@ class Corpus:
     def _check_invariants(self) -> None:
         assert set().union(*self.fingerprints) == set(self.behavior_counts)
 
-        covering_nodes_choices = {
-            Choices(tuple(n.value for n in nodes))
-            for nodes in self.fingerprints.values()
-        }
         # under 100% stability, we expect these lengths to be equal. However, we
         # might execute choices A once with fingerprint F1 and again with a
         # different fingerprint F2, in which case we have one corpus element and
@@ -146,9 +150,22 @@ class Corpus:
             len(self.fingerprints),
             self.database_key,
         )
+
+        for fingerprint, nodes in self.fingerprints.items():
+            choices = Choices(tuple(n.value for n in nodes))
+            assert choices in self.corpus, (fingerprint, choices)
+
+        fingerprints_choices = [
+            Choices(tuple(n.value for n in nodes))
+            for nodes in self.fingerprints.values()
+        ]
+        for choices, count in self._count_fingerprints.items():
+            assert count > 0  # we drop choices from _count_fingerprints once evicted
+            assert fingerprints_choices.count(choices) == count
+
         assert self.corpus.issubset(
-            covering_nodes_choices
-        ), self.corpus.symmetric_difference(covering_nodes_choices)
+            set(fingerprints_choices)
+        ), self.corpus.symmetric_difference(fingerprints_choices)
 
     def _add_fingerprint(
         self,
@@ -166,16 +183,19 @@ class Corpus:
                     self.database_key, result.choices, observation
                 )
         self.corpus.add(choices)
+        self._count_fingerprints[choices] += 1
 
         # Reset our seen branch counts.  This is essential because changing our
         # corpus alters the probability of seeing each branch in future.
         # For details see AFL-fast, esp. the markov-chain trick.
         self.behavior_counts = Counter(fingerprint | set(self.behavior_counts))
 
-    def _evict_choices(self, choices: ChoicesT) -> None:
+    def _evict_choices(self, choices: Choices) -> None:
         # remove an outdated choice sequence and its observation(s) from the
         # database
-        self.corpus.remove(Choices(choices))
+        assert self._count_fingerprints[choices] == 0
+        del self._count_fingerprints[choices]
+        self.corpus.remove(choices)
         self._db.delete_corpus(self.database_key, choices)
         for observation in list(
             self._db.fetch_corpus_observations(self.database_key, choices)
@@ -237,10 +257,16 @@ class Corpus:
             self._add_fingerprint(fingerprint, result, observation=observation)
             self._check_invariants()
             return True
-        elif sort_key(result.nodes) < sort_key(self.fingerprints[fingerprint]):
-            existing_choices = tuple(n.value for n in self.fingerprints[fingerprint])
+
+        if sort_key(result.nodes) < sort_key(self.fingerprints[fingerprint]):
+            existing_choices = Choices(
+                tuple(n.value for n in self.fingerprints[fingerprint])
+            )
+
+            self._count_fingerprints[existing_choices] -= 1
             self._add_fingerprint(fingerprint, result, observation=observation)
-            self._evict_choices(existing_choices)
+            if self._count_fingerprints[existing_choices] == 0:
+                self._evict_choices(existing_choices)
             self._check_invariants()
             return True
 

--- a/src/hypofuzz/database.py
+++ b/src/hypofuzz/database.py
@@ -3,11 +3,20 @@ import hashlib
 import json
 from base64 import b64decode, b64encode
 from collections import defaultdict, deque
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, is_dataclass
 from enum import Enum
 from functools import cache, lru_cache
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    Optional,
+    Protocol,
+    TypeVar,
+    Union,
+    overload,
+)
 
 from hypothesis import settings
 from hypothesis.database import (
@@ -25,6 +34,12 @@ if TYPE_CHECKING:
     from typing import TypeAlias
 
 ChoicesT: "TypeAlias" = tuple[ChoiceT, ...]
+T = TypeVar("T", covariant=True)
+
+
+class HashableIterable(Protocol[T]):
+    def __hash__(self) -> int: ...
+    def __iter__(self) -> Iterator[T]: ...
 
 
 class HypofuzzEncoder(json.JSONEncoder):
@@ -332,8 +347,11 @@ def worker_identity_key(key: bytes, uuid: str) -> bytes:
     return key + b".worker_identity." + uuid.encode("ascii")
 
 
+# `choices` required to be hashable for @lru_cache
 @lru_cache(maxsize=512)
-def corpus_observation_key(key: bytes, choices: Union[ChoicesT, bytes]) -> bytes:
+def corpus_observation_key(
+    key: bytes, choices: Union[HashableIterable[ChoiceT], bytes]
+) -> bytes:
     choices_bytes = choices if isinstance(choices, bytes) else choices_to_bytes(choices)
     return (
         key + corpus_key + b"." + hashlib.sha1(choices_bytes).digest() + b".observation"
@@ -345,7 +363,9 @@ def failure_key(key: bytes, *, shrunk: bool) -> bytes:
 
 
 @lru_cache(maxsize=512)
-def failure_observation_key(key: bytes, choices: Union[ChoicesT, bytes]) -> bytes:
+def failure_observation_key(
+    key: bytes, choices: Union[HashableIterable[ChoiceT], bytes]
+) -> bytes:
     choices_bytes = choices if isinstance(choices, bytes) else choices_to_bytes(choices)
     return (
         key
@@ -434,10 +454,10 @@ class HypofuzzDatabase:
 
     # corpus (corpus_key)
 
-    def save_corpus(self, key: bytes, choices: ChoicesT) -> None:
+    def save_corpus(self, key: bytes, choices: Iterable[ChoiceT]) -> None:
         self.save(key + corpus_key, choices_to_bytes(choices))
 
-    def delete_corpus(self, key: bytes, choices: ChoicesT) -> None:
+    def delete_corpus(self, key: bytes, choices: Iterable[ChoiceT]) -> None:
         self.delete(key + corpus_key, choices_to_bytes(choices))
 
     @overload
@@ -479,14 +499,14 @@ class HypofuzzDatabase:
             self.delete_corpus_observation(key, choices, observation)
 
     def delete_corpus_observation(
-        self, key: bytes, choices: ChoicesT, observation: Observation
+        self, key: bytes, choices: HashableIterable[ChoiceT], observation: Observation
     ) -> None:
         self.delete(corpus_observation_key(key, choices), self._encode(observation))
 
     def fetch_corpus_observation(
         self,
         key: bytes,
-        choices: Union[ChoicesT, bytes],
+        choices: Union[HashableIterable[ChoiceT], bytes],
     ) -> Optional[Observation]:
         # We expect there to be only a single entry. If there are multiple, we
         # arbitrarily pick one to return.
@@ -498,7 +518,7 @@ class HypofuzzDatabase:
     def fetch_corpus_observations(
         self,
         key: bytes,
-        choices: Union[ChoicesT, bytes],
+        choices: Union[HashableIterable[ChoiceT], bytes],
     ) -> Iterable[Observation]:
         for value in self.fetch(corpus_observation_key(key, choices)):
             if observation := Observation.from_json(value):

--- a/src/hypofuzz/entrypoint.py
+++ b/src/hypofuzz/entrypoint.py
@@ -146,18 +146,18 @@ def _fuzz_impl(numprocesses: int, pytest_args: tuple[str, ...]) -> None:
     if numprocesses <= 1:
         _fuzz_several(pytest_args=pytest_args, nodeids=[t.nodeid for t in tests])
     else:
-        processes = []
+        processes: list[Process] = []
         for i in range(numprocesses):
             # Round-robin for large test suites; all-on-all for tiny, etc.
-            nodes: set[str] = set()
+            nodeids: set[str] = set()
             for ix in range(numprocesses):
-                nodes.update(t.nodeid for t in tests[i + ix :: numprocesses])
-                if len(nodes) >= 10:  # enough to prioritize between
+                nodeids.update(t.nodeid for t in tests[i + ix :: numprocesses])
+                if len(nodeids) >= 10:  # enough to prioritize between
                     break
 
             p = Process(
                 target=_fuzz_several,
-                kwargs={"pytest_args": pytest_args, "nodeids": nodes},
+                kwargs={"pytest_args": pytest_args, "nodeids": nodeids},
             )
             p.start()
             processes.append(p)


### PR DESCRIPTION
This fixes a keyerror bug on master, where we tried to `self.corpus.remove(choices)` when the choice sequence wasn't actually in our corpus, because two fingerprints F1 and F2 both had the same choice sequence `choices`, and F1 evicted the choices from the corpus first (no error), followed by F2 later (which errored). Now we only evict when a choice sequence has no corresponding fingerprints.