### PR TITLE
Add selection ability to tyche mosaic charts

### DIFF
--- a/src/hypofuzz/frontend/package-lock.json
+++ b/src/hypofuzz/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@types/highlight.js": "^9.12.4",
         "d3": "^7.8.5",
         "highlight.js": "^11.11.1",
+        "immutable": "^5.1.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.22.0",
@@ -2741,10 +2742,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.0.3.tgz",
-      "integrity": "sha512-P8IdPQHq3lA1xVeBRi5VPqUm5HDgKnx0Ru51wZz5mjxHr5n3RWhjIpOFU7ybkUxfB+5IToy+OLaHYDBIWsv+uw==",
-      "devOptional": true,
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.2.tgz",
+      "integrity": "sha512-qHKXW1q6liAk1Oys6umoaZbDRqjcjgSrbnrifHsfsttza7zcvRAsL7mMV6xWcyhwQy7Xj5v4hhbr6b+iDYwlmQ==",
       "license": "MIT"
     },
     "node_modules/import-fresh": {

--- a/src/hypofuzz/frontend/package.json
+++ b/src/hypofuzz/frontend/package.json
@@ -16,6 +16,7 @@
     "@types/highlight.js": "^9.12.4",
     "d3": "^7.8.5",
     "highlight.js": "^11.11.1",
+    "immutable": "^5.1.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.0",

--- a/src/hypofuzz/frontend/src/context/DataProvider.tsx
+++ b/src/hypofuzz/frontend/src/context/DataProvider.tsx
@@ -53,6 +53,20 @@ type TestsAction =
       observations: Observation[]
     }
 
+function computeUniqueness(observations: Observation[]) {
+  const reprCounts = new Map<string, number>()
+
+  observations.forEach(obs => {
+    reprCounts.set(obs.representation, (reprCounts.get(obs.representation) || 0) + 1)
+  })
+
+  observations.forEach(observation => {
+    const count = reprCounts.get(observation.representation)!
+    observation.isUnique = count == 1
+    observation.isDuplicate = count > 1
+  })
+}
+
 function testsReducer(
   state: Map<string, Test>,
   action: TestsAction,
@@ -107,9 +121,11 @@ function testsReducer(
         test.rolling_observations = test.rolling_observations
           .sortKey(observation => observation.run_start)
           .slice(-300)
+        computeUniqueness(test.rolling_observations)
       } else {
         console.assert(observation_type === "corpus")
         test.corpus_observations.push(...observations)
+        computeUniqueness(test.corpus_observations)
       }
       return newState
     }

--- a/src/hypofuzz/frontend/src/styles.scss
+++ b/src/hypofuzz/frontend/src/styles.scss
@@ -691,6 +691,7 @@ pre code.hljs {
             font-weight: 600;
             font-weight: 600;
             color: #2c3e50;
+            cursor: pointer;
         }
 
         &__row-header {
@@ -729,9 +730,25 @@ pre code.hljs {
             margin: 0 2px;
             border-radius: 3px;
             transition: opacity 0.1s ease;
+            cursor: pointer;
 
             &:hover {
                 opacity: 0.9;
+            }
+
+            &--selected {
+                position: relative;
+
+                &::after {
+                    content: "";
+                    position: absolute;
+                    top: 2px;
+                    left: 2px;
+                    right: 2px;
+                    bottom: 2px;
+                    border: 2.5px solid white;
+                    border-radius: 3px;
+                }
             }
         }
 

--- a/src/hypofuzz/frontend/src/tyche/MosaicChart.tsx
+++ b/src/hypofuzz/frontend/src/tyche/MosaicChart.tsx
@@ -1,6 +1,11 @@
-import React, { useEffect, useMemo } from "react"
-import * as d3 from "d3"
+import React, { useEffect, useMemo, useState } from "react"
+import { select as d3_select } from "d3-selection"
+import { Set, List } from "immutable"
 import { Observation } from "../types/dashboard"
+
+const d3 = {
+  select: d3_select,
+}
 
 const MAX_MOSAIC_WIDTH = 640
 
@@ -11,6 +16,7 @@ interface MosaicChartProps {
   verticalAxis: AxisItem[]
   horizontalAxis: AxisItem[]
   cssStyle: (row: string, column: string) => React.CSSProperties
+  onSelection?: (selectedCells: Set<List<number>>) => void
 }
 
 interface Cell {
@@ -59,7 +65,10 @@ export function MosaicChart({
   verticalAxis,
   horizontalAxis,
   cssStyle = (row, column) => ({}),
+  onSelection,
 }: MosaicChartProps) {
+  const [selectedCells, setSelectedCells] = useState(Set<List<number>>())
+
   const cells: Cell[][] = []
   const rowTotals: number[] = Array(verticalAxis.length).fill(0)
   const columnTotals: number[] = Array(horizontalAxis.length).fill(0)
@@ -102,6 +111,39 @@ export function MosaicChart({
   const visibleCols = columnTotals
     .map((total, index) => (total > 0 ? index : null))
     .filter(index => index !== null)
+
+  const cellClick = (rowIndex: number | null, colIndex: number | null) => {
+    let newSelection = Set<List<number>>()
+
+    if (rowIndex !== null && colIndex !== null) {
+      const cell = List([rowIndex, colIndex])
+      // if this cell is already selected and it's the only selection, deselect it
+      if (selectedCells.equals(Set([cell]))) {
+        newSelection = Set()
+      } else {
+        newSelection = Set([cell])
+      }
+    } else if (rowIndex !== null) {
+      console.assert(colIndex === null)
+      // select all cells in this row
+      visibleCols.forEach(colIdx => {
+        if (cells[rowIndex][colIdx].count > 0) {
+          newSelection = newSelection.add(List([rowIndex, colIdx]))
+        }
+      })
+    } else if (colIndex !== null) {
+      console.assert(rowIndex === null)
+      // select all cells in this column
+      visibleRows.forEach(rowIdx => {
+        if (cells[rowIdx][colIndex].count > 0) {
+          newSelection = newSelection.add(List([rowIdx, colIndex]))
+        }
+      })
+    }
+
+    setSelectedCells(newSelection)
+    onSelection?.(newSelection)
+  }
 
   useEffect(() => {
     d3.select("body")
@@ -238,6 +280,7 @@ export function MosaicChart({
                     : "translateX(-50%)",
                 textAlign: isFirst ? "left" : isLast ? "right" : "center",
               }}
+              onClick={() => cellClick(null, colIndex)}
             >
               {horizontalAxis[colIndex][0]}
             </div>
@@ -257,7 +300,9 @@ export function MosaicChart({
             className="tyche__mosaic__row-header"
             style={{
               width: `${rowHeaderWidth}px`,
+              cursor: "pointer",
             }}
+            onClick={() => cellClick(rowIndex, null)}
           >
             {verticalAxis[rowIndex][0]}
           </div>
@@ -270,16 +315,18 @@ export function MosaicChart({
                 return null
               }
 
+              const isSelected = selectedCells.has(List([rowIndex, colIndex]))
               return (
                 <div
                   key={`cell-${rowIndex}-${colIndex}`}
-                  className="tyche__mosaic__cell"
+                  className={`tyche__mosaic__cell${isSelected ? " tyche__mosaic__cell--selected" : ""}`}
                   style={{
                     width: `${cell.widthPercent}%`,
                     minWidth: `${minCellWidth}px`,
                     minHeight: `${minCellHeight}px`,
                     ...cssStyle(verticalAxis[rowIndex][0], horizontalAxis[colIndex][0]),
                   }}
+                  onClick={() => cellClick(rowIndex, colIndex)}
                   onMouseEnter={e =>
                     showTooltip(
                       e,

--- a/src/hypofuzz/frontend/src/tyche/Samples.tsx
+++ b/src/hypofuzz/frontend/src/tyche/Samples.tsx
@@ -2,34 +2,15 @@ import { Observation } from "../types/dashboard"
 import { MosaicChart } from "./MosaicChart"
 import { TYCHE_COLOR } from "./Tyche"
 import { TycheSection } from "./TycheSection"
-import { useMemo } from "react"
+import { Set, List } from "immutable"
 
-export function Samples({ observations }: { observations: Observation[] }) {
-  function isPassed(observation: Observation) {
-    return observation.status === "passed"
-  }
-  function isInvalid(observation: Observation) {
-    return observation.status === "gave_up"
-  }
-
-  const reprCounts = useMemo(() => {
-    const counts = new Map<string, number>()
-    for (const observation of observations) {
-      counts.set(
-        observation.representation,
-        (counts.get(observation.representation) || 0) + 1,
-      )
-    }
-    return counts
-  }, [observations])
-
-  function isUnique(observation: Observation) {
-    return reprCounts.get(observation.representation)! == 1
-  }
-  function isDuplicate(observation: Observation) {
-    return reprCounts.get(observation.representation)! > 1
-  }
-
+export function Samples({
+  observations,
+  onSelection,
+}: {
+  observations: Observation[]
+  onSelection?: (selectedCells: Set<List<number>>) => void
+}) {
   function cellStyle(row: string, column: string): React.CSSProperties {
     const style: React.CSSProperties = {}
 
@@ -53,14 +34,15 @@ export function Samples({ observations }: { observations: Observation[] }) {
       <MosaicChart
         observations={observations}
         verticalAxis={[
-          ["Passed", isPassed],
-          ["Invalid", isInvalid],
+          ["Passed", obs => obs.status === "passed"],
+          ["Invalid", obs => obs.status === "gave_up"],
         ]}
         horizontalAxis={[
-          ["Unique", isUnique],
-          ["Duplicate", isDuplicate],
+          ["Unique", obs => obs.isUnique ?? false],
+          ["Duplicate", obs => obs.isDuplicate ?? false],
         ]}
         cssStyle={cellStyle}
+        onSelection={onSelection}
       />
     </TycheSection>
   )

--- a/src/hypofuzz/frontend/src/tyche/Tyche.tsx
+++ b/src/hypofuzz/frontend/src/tyche/Tyche.tsx
@@ -1,9 +1,10 @@
-import { useState } from "react"
-import { Test } from "../types/dashboard"
+import { useState, useEffect } from "react"
+import { Test, Observation } from "../types/dashboard"
 import { Toggle } from "../components/Toggle"
 import { Features } from "./Features"
 import { Samples } from "./Samples"
 import { Representation } from "./Representation"
+import { Set, List } from "immutable"
 
 export enum TYCHE_COLOR {
   // https://github.com/tyche-pbt/tyche-extension/blob/main/webview-ui/src/utilities/colors.ts
@@ -23,12 +24,34 @@ export function Tyche({ test }: { test: Test }) {
   const [observationType, setObservationType] = useState<"covering" | "rolling">(
     "covering",
   )
+  const [selectedCells, setSelectedCells] = useState<Set<List<number>>>(Set())
 
   const observations =
     observationType === "rolling"
       ? // newest first for rolling observations
         test.rolling_observations.sortKey(observation => -observation.run_start)
       : test.corpus_observations
+
+  const filteredObservations =
+    selectedCells.size === 0
+      ? observations
+      : observations.filter(observation => {
+          const verticalAxis: ((obs: Observation) => boolean)[] = [
+            obs => obs.status === "passed",
+            obs => obs.status === "gave_up",
+          ]
+          const horizontalAxis: ((obs: Observation) => boolean)[] = [
+            obs => obs.isUnique ?? false,
+            obs => obs.isDuplicate ?? false,
+          ]
+          return selectedCells.some(cellCoords => {
+            const [rowIndex, colIndex] = cellCoords.toArray()
+            const verticalPredicate = verticalAxis[rowIndex]
+            const horizontalPredicate = horizontalAxis[colIndex]
+
+            return verticalPredicate(observation) && horizontalPredicate(observation)
+          })
+        })
 
   return (
     <div className="card">
@@ -56,10 +79,10 @@ export function Tyche({ test }: { test: Test }) {
       </div>
       {observations.length > 0 ? (
         <>
-          <Samples observations={observations} />
+          <Samples observations={observations} onSelection={setSelectedCells} />
           <Features observations={observations} />
           <Representation
-            observations={observations}
+            observations={filteredObservations}
             observationType={observationType}
           />
         </>

--- a/src/hypofuzz/frontend/src/types/dashboard.ts
+++ b/src/hypofuzz/frontend/src/types/dashboard.ts
@@ -157,6 +157,9 @@ enum ObservationStatus {
 }
 
 export class Observation extends Dataclass<Observation> {
+  public isDuplicate: boolean | null = null
+  public isUnique: boolean | null = null
+
   // https://hypothesis.readthedocs.io/en/latest/reference/integrations.html#test-case
   constructor(
     public type: string,


### PR DESCRIPTION
Allow clicking on mosaic chart sections and headers to filter representations to those for the selected cells. I need to figure out a better way to communicate that selecting mosaic chart cells has an effect on the display of other tyche sections.

I think we'll want to extend this to filtering down other features as well. I think this could enable really powerful exploratory work ("what do the features with duplicate reprs and my_feature=2 look like?"). I'm not sure what the best UX is though. 