### PR TITLE
Refresh ui colors

### DIFF
--- a/src/hypofuzz/frontend/src/main.tsx
+++ b/src/hypofuzz/frontend/src/main.tsx
@@ -1,4 +1,4 @@
-import "./styles.scss"
+import "./styles/styles.scss"
 // ensure our array prototype definitions get loaded
 import "./utils/prototypes"
 

--- a/src/hypofuzz/frontend/src/styles/styles.scss
+++ b/src/hypofuzz/frontend/src/styles/styles.scss
@@ -1,4 +1,9 @@
 /* using BEM for naming convention https://getbem.com/ */
+@use "theme.scss" as *;
+
+// lato only has these weights: 100 / 300 / 400 / 700 / 900
+// https://fonts.google.com/specimen/Lato
+@import url("https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&display=swap");
 
 // css reset
 
@@ -14,8 +19,18 @@
 
 body {
     font-family:
-        -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial,
-        sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        "Lato",
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        "Helvetica Neue",
+        Arial,
+        sans-serif,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol";
+    background-color: hsla($primary-h, $primary-s, $primary-l, 0.05);
 }
 
 input,
@@ -26,13 +41,6 @@ select {
 }
 
 // actual styles
-
-$color-primary: #32465b;
-
-$color-neutral: rgba(179, 170, 170, 0.2);
-$color-failure: rgba(237, 120, 107, 0.2);
-$color-warning: rgba(255, 215, 0, 0.2);
-$color-success: rgba(71, 204, 126, 0.2);
 
 $mobile-breakpoint: 768px;
 

--- a/src/hypofuzz/frontend/src/styles/theme.scss
+++ b/src/hypofuzz/frontend/src/styles/theme.scss
@@ -1,0 +1,15 @@
+$primary-h: 210;
+$primary-s: 50%;
+$primary-l: 30%;
+$color-primary: hsl($primary-h, $primary-s, $primary-l);
+
+$secondary-h: 24;
+$secondary-s: 80%;
+$secondary-l: 60%;
+$color-secondary: hsl($secondary-h, $secondary-s, $secondary-l);
+
+// TODO these are converted from rgb, no principled reason for the specific values
+$color-neutral: hsla(0, 5%, 68%, 0.2);
+$color-failure: hsla(6, 78%, 67%, 0.2);
+$color-warning: hsla(45, 100%, 50%, 0.2);
+$color-success: hsla(142, 54%, 54%, 0.2);


### PR DESCRIPTION
I did a bit of a brand color refresh. Originally for the landing page, but when I applied it to the dashboard I was surprised how much more lively it makes it feel.

* Use lato font
* Use blue (primary) and orange (secondary) colors, to match the butterfly colors
  *  not really sold on the orange but we aren't using it anywhere yet