### PR TITLE
Rename FuzzProcess to FuzzTarget

### DIFF
--- a/src/hypofuzz/dashboard/dashboard.py
+++ b/src/hypofuzz/dashboard/dashboard.py
@@ -47,7 +47,7 @@ from hypofuzz.database import (
     Report,
     ReportWithDiff,
 )
-from hypofuzz.hypofuzz import FuzzProcess
+from hypofuzz.hypofuzz import FuzzTarget
 from hypofuzz.utils import convert_to_fuzzjson
 
 # these two test dicts always contain the same values, just with different access
@@ -589,7 +589,7 @@ def get_failure_observations(database_key: bytes) -> dict[str, Observation]:
     return failure_observations
 
 
-def _load_initial_state(fuzz_target: FuzzProcess) -> None:
+def _load_initial_state(fuzz_target: FuzzTarget) -> None:
     assert COLLECTION_RESULT is not None
     assert db is not None
     # a fuzz target (= node id) may have many database keys over time as the
@@ -634,7 +634,7 @@ def _load_initial_state(fuzz_target: FuzzProcess) -> None:
     TESTS_BY_KEY[fuzz_target.database_key] = test
 
 
-async def load_initial_state(fuzz_target: FuzzProcess) -> None:
+async def load_initial_state(fuzz_target: FuzzTarget) -> None:
     global LOADING_STATE
 
     await trio.to_thread.run_sync(_load_initial_state, fuzz_target)

--- a/src/hypofuzz/dashboard/patching.py
+++ b/src/hypofuzz/dashboard/patching.py
@@ -7,7 +7,7 @@ from hypothesis.configuration import storage_directory
 from hypothesis.extra._patching import FAIL_MSG, get_patch_for, make_patch, save_patch
 
 from hypofuzz.database import Phase
-from hypofuzz.hypofuzz import FuzzProcess
+from hypofuzz.hypofuzz import FuzzTarget
 
 if TYPE_CHECKING:
     from hypofuzz.dashboard.test import Test
@@ -18,7 +18,7 @@ make_patch_cached = lru_cache(maxsize=1024)(make_patch)
 
 
 def make_and_save_patches(
-    fuzz_targets: list[FuzzProcess],
+    fuzz_targets: list[FuzzTarget],
     tests: dict[str, "Test"],
     *,
     canonical: bool = True,

--- a/src/hypofuzz/hypofuzz.py
+++ b/src/hypofuzz/hypofuzz.py
@@ -67,10 +67,10 @@ class HypofuzzStateForActualGivenExecution(StateForActualGivenExecution):
         return False
 
 
-class FuzzProcess:
+class FuzzTarget:
     """
-    Thin wrapper around HypofuzzProvider, which also handles shrinking failures
-    in a way that saves observations correctly for Hypofuzz.
+    FuzzTarget is a thin wrapper around HypofuzzProvider, which also handles
+    shrinking failures in a way that saves observations correctly for Hypofuzz.
     """
 
     @classmethod
@@ -81,8 +81,7 @@ class FuzzProcess:
         database: HypofuzzDatabase,
         extra_kw: Optional[dict[str, object]] = None,
         pytest_item: Optional[pytest.Item] = None,
-    ) -> "FuzzProcess":
-        """Return a FuzzProcess for an @given-decorated test function."""
+    ) -> "FuzzTarget":
         _, _, stuff = process_arguments_to_given(
             wrapped_test,
             arguments=(),
@@ -111,7 +110,6 @@ class FuzzProcess:
         wrapped_test: Callable,
         pytest_item: Optional[pytest.Item] = None,
     ) -> None:
-        """Construct a FuzzProcess from specific arguments."""
         self.random = Random(random_seed)
         self._test_fn = test_fn
         self._stuff = stuff
@@ -260,10 +258,10 @@ class FuzzProcess:
         return corpus is not None and bool(corpus.interesting_examples)
 
 
-def fuzz_several(targets: list[FuzzProcess], random_seed: Optional[int] = None) -> None:
+def fuzz_several(targets: list[FuzzTarget], random_seed: Optional[int] = None) -> None:
     """Take N fuzz targets and run them all."""
     random = Random(random_seed)
-    targets: SortedKeyList[FuzzProcess, int] = SortedKeyList(
+    targets: SortedKeyList[FuzzTarget, int] = SortedKeyList(
         targets, lambda p: p.provider.since_new_branch
     )
 
@@ -272,7 +270,7 @@ def fuzz_several(targets: list[FuzzProcess], random_seed: Optional[int] = None) 
     # TODO: make this aware of test runtime, so it adapts for behaviors-per-second
     #       rather than behaviors-per-input.
 
-    dispatch: dict[bytes, list[FuzzProcess]] = defaultdict(list)
+    dispatch: dict[bytes, list[FuzzTarget]] = defaultdict(list)
     for target in targets:
         dispatch[target.database_key].append(target)
 

--- a/src/hypofuzz/provider.py
+++ b/src/hypofuzz/provider.py
@@ -389,7 +389,7 @@ class HypofuzzProvider(PrimitiveProvider):
 
         assert observation.type == "test_case"
         # run_start is normally relative to StateForActualGivenExecution, which we
-        # re-use per FuzzProcess. Overwrite with the current timestamp for use
+        # re-use per FuzzTarget. Overwrite with the current timestamp for use
         # in sorting observations. This is not perfectly reliable in a
         # distributed setting, but is good enough.
         observation.run_start = self._state.start_time

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -7,10 +7,10 @@ from pathlib import Path
 import pytest
 
 from hypofuzz.collection import collect_tests
-from hypofuzz.hypofuzz import FuzzProcess
+from hypofuzz.hypofuzz import FuzzTarget
 
 
-def collect(code: str) -> list[FuzzProcess]:
+def collect(code: str) -> list[FuzzTarget]:
     code = (
         inspect.cleandoc(
             """

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -18,7 +18,7 @@ from hypofuzz.corpus import (
     sort_key,
 )
 from hypofuzz.database import HypofuzzDatabase
-from hypofuzz.hypofuzz import FuzzProcess
+from hypofuzz.hypofuzz import FuzzTarget
 
 
 def behaviors(fnames=st.sampled_from("abc")) -> st.SearchStrategy[frozenset[Branch]]:
@@ -121,7 +121,7 @@ def test_corpus_resets_branch_counts_on_new_coverage():
         if x == 2:
             pass
 
-    process = FuzzProcess.from_hypothesis_test(
+    process = FuzzTarget.from_hypothesis_test(
         test_a, database=HypofuzzDatabase(InMemoryExampleDatabase())
     )
     provider = process.provider

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -16,8 +16,8 @@ pytestmark = pytest.mark.skipif(
 
 class Collector:
     """
-    A Corpus-compatible collector (can be used in FuzzProcess._run_test_on) which
-    improves branch readability in tests:
+    A Corpus-compatible coverage collector which improves branch readability in
+    tests:
     * drop the filename from branches (assumes single-file usage)
     * offset branches relative to the first line of the passed function (decorators
       count as part of the definition)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -9,7 +9,7 @@ from hypothesis.database import (
 )
 
 from hypofuzz.database import HypofuzzDatabase, Phase, test_keys_key
-from hypofuzz.hypofuzz import FuzzProcess
+from hypofuzz.hypofuzz import FuzzTarget
 
 
 def test_database_stores_reports_and_metadata_correctly(tmp_path):
@@ -45,7 +45,7 @@ def test_database_state():
         if x:
             pass
 
-    process = FuzzProcess.from_hypothesis_test(test_a, database=db)
+    process = FuzzTarget.from_hypothesis_test(test_a, database=db)
     process._execute_once(process.new_conjecture_data(choices=[2]))
     process.provider.db._db._join()
 
@@ -102,7 +102,7 @@ def test_adds_failures_to_database():
     def test_a(x):
         assert x != 10
 
-    process = FuzzProcess.from_hypothesis_test(test_a, database=db)
+    process = FuzzTarget.from_hypothesis_test(test_a, database=db)
     for _ in range(50):
         process.run_one()
 

--- a/tests/test_fuzz_process.py
+++ b/tests/test_fuzz_process.py
@@ -7,7 +7,7 @@ from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.internal.conjecture.data import Status
 
 from hypofuzz.database import HypofuzzDatabase
-from hypofuzz.hypofuzz import FuzzProcess
+from hypofuzz.hypofuzz import FuzzTarget
 
 
 def test_fuzz_one_process():
@@ -16,7 +16,7 @@ def test_fuzz_one_process():
     def test_a(x):
         pass
 
-    fp = FuzzProcess.from_hypothesis_test(
+    fp = FuzzTarget.from_hypothesis_test(
         test_a, database=HypofuzzDatabase(InMemoryExampleDatabase())
     )
     for _ in range(100):
@@ -38,7 +38,7 @@ def test_fuzz_one_process_explain_mode():
         if x:
             raise CustomError(f"x={x}")
 
-    fp = FuzzProcess.from_hypothesis_test(test_fails, database=db)
+    fp = FuzzTarget.from_hypothesis_test(test_fails, database=db)
     while not fp.has_found_failure:
         fp.run_one()
 
@@ -72,7 +72,7 @@ def test_observations_use_pytest_nodeid(pytest_item, expected_property):
         pass
 
     db = HypofuzzDatabase(InMemoryExampleDatabase())
-    fp = FuzzProcess.from_hypothesis_test(test_a, database=db, pytest_item=pytest_item)
+    fp = FuzzTarget.from_hypothesis_test(test_a, database=db, pytest_item=pytest_item)
     assert fp.nodeid == expected_property
 
     fp.run_one()


### PR DESCRIPTION
in preparation for a `FuzzWorker` which manages multiple targets; I want to avoid the connotation of "fuzzprocess" <-> "cpu core"