### PR TITLE
Use a `distribute_nodes` function

### DIFF
--- a/src/hypofuzz/bayes.py
+++ b/src/hypofuzz/bayes.py
@@ -1,0 +1,58 @@
+from collections.abc import Sequence
+from typing import Any
+
+
+def distribute_nodes(
+    nodeids: Sequence[str], estimators: Sequence[float], *, n: int
+) -> tuple[tuple[str, ...], ...]:
+    # We have x nodes node_i, each with an estimator \hat{v}_i for "behaviors per
+    # second". We have n bins (processes), and we want to distribute node_i
+    # into the n bins such that we maximize overall behaviors per second.
+    #
+    # If our estimators \hat{v}_i were static, then this is trivial: the
+    # overall behaviors per second is `sum from i=1 to c of max(p_i)`. Of course,
+    # our estimators are *not* static. Which means we are optimizing over something
+    # more complicated - a set of multi-armed bandit problems perhaps?
+    #
+    # A more naive quantity to maximize (minimize) is the largest bin sum.
+    # So we are minimizing `max(sum(p_i) for i in c)`. This is related to
+    # "makespan minimization", and is a classic bin packing problem. Optimality
+    # is NP complete, so we approximate the optimal solution with a greedy one,
+    # specifically "longest processing time first scheduling".
+    #
+    # (intuitively, we assign the "best" nodes to processes first. So with
+    # e.g. 10 processes with estimator of \hat{v}_i = 1 behavior per second (which
+    # is really good!) they would all go to different processes (at least until
+    # the cap of n processes), which is what we want.
+
+    assert len(nodeids) == len(estimators)
+    # estimators of 0 are mathematically valid, but semantically weird, and much
+    # more likely to be indicative of a logic error
+    assert all(estimator > 0 for estimator in estimators)
+
+    bins: list[list[Any]] = [[] for _ in range(n)]
+    nodes = [
+        {"nodeid": nodeid, "estimator": estimator}
+        for nodeid, estimator in zip(nodeids, estimators)
+    ]
+
+    # first, we sort the node_i in decreasing order by their estimator.
+    nodes.sort(key=lambda node: node["estimator"], reverse=True)  # type: ignore
+
+    # If we have fewer than `n` nodes, we repeat the list of nodes in decreasing
+    # order of their estimator until we reach `n` nodes. This ensures every
+    # processes receives a node (in fact, in this case, exactly one).
+    node_idx = 0
+    while len(nodes) < n:
+        nodes.append(nodes[node_idx])
+        node_idx = (node_idx + 1) % len(nodes)
+
+    # then, we assign each node_i to the partition with the least sum.
+    for node in nodes:
+        smallest_bin = min(
+            bins,
+            key=lambda bin: sum(node["estimator"] for node in bin),
+        )
+        smallest_bin.append(node)
+
+    return tuple(tuple(node["nodeid"] for node in bin) for bin in bins)

--- a/tests/test_bayes.py
+++ b/tests/test_bayes.py
@@ -1,0 +1,33 @@
+from hypothesis import given, strategies as st
+import itertools
+
+from hypofuzz.bayes import distribute_nodes
+
+
+@given(
+    st.lists(
+        st.tuples(
+            st.integers(0, 1000).map(lambda n: f"node{n}"),
+            st.floats(min_value=0, allow_infinity=False, exclude_min=True),
+        ),
+        min_size=1,
+    ),
+    st.integers(1, 100),
+)
+def test_distribute_nodes(items, n):
+    nodeids = [item[0] for item in items]
+    estimators = [item[1] for item in items]
+    partitions = distribute_nodes(nodeids, estimators, n=n)
+
+    total_nodes = sum(len(partition) for partition in partitions)
+    assert total_nodes == n if len(nodeids) < n else len(nodeids)
+    assert all(len(partition) > 0 for partition in partitions)
+
+
+@given(st.integers(4, 100))
+def test_distribute_nodes_more_processes_than_nodes(n):
+    # when there are more processes than nodes, we should see the highest value
+    # nodes getting assigned to processes first.
+    assert distribute_nodes(["1", "2", "3"], [1, 3, 2], n=n) == tuple(
+        itertools.islice(itertools.cycle([("2",), ("3",), ("1",)]), n)
+    )


### PR DESCRIPTION
This doesn't actually incorporate estimator state right now. It just hardcodes an estimator of `1.0` for all nodes. But the groundwork and tests is all here for when we do plug in an estimator. (we weren't using estimator state before, so this doesn't change the status quo).