### PR TITLE
Use softmax for multi-armed bandit

### DIFF
--- a/deps/check.txt
+++ b/deps/check.txt
@@ -16,12 +16,12 @@ h2==4.2.0                 # via hypercorn
 hpack==4.1.0              # via h2
 hypercorn==0.17.3         # via -r deps/check.in
 hyperframe==6.1.0         # via h2
-hypothesis==6.135.5       # via -r deps/check.in
+hypothesis==6.135.10      # via -r deps/check.in
 idna==3.10                # via anyio, trio
 iniconfig==2.1.0          # via pytest
-libcst==1.8.1             # via shed
+libcst==1.8.2             # via shed
 mccabe==0.7.0             # via flake8
-mypy==1.16.0              # via -r deps/check.in
+mypy==1.16.1              # via -r deps/check.in
 mypy-extensions==1.1.0    # via black, mypy
 outcome==1.3.0.post0      # via trio
 packaging==25.0           # via black, pytest
@@ -47,7 +47,7 @@ taskgroup==0.2.2          # via hypercorn
 tokenize-rt==6.2.0        # via pyupgrade
 tomli==2.2.1              # via black, hypercorn, mypy, pytest
 trio==0.30.0              # via -r deps/check.in
-types-requests==2.32.0.20250602  # via -r deps/check.in
-typing-extensions==4.14.0  # via anyio, black, exceptiongroup, hypercorn, mypy, sortedcontainers-stubs, starlette, taskgroup
+types-requests==2.32.4.20250611  # via -r deps/check.in
+typing-extensions==4.14.0  # via anyio, black, exceptiongroup, hypercorn, libcst, mypy, sortedcontainers-stubs, starlette, taskgroup
 urllib3==2.4.0            # via types-requests
 wsproto==1.2.0            # via hypercorn

--- a/deps/docs.txt
+++ b/deps/docs.txt
@@ -10,10 +10,10 @@ attrs==25.3.0             # via hypothesis, outcome, trio
 babel==2.17.0             # via sphinx
 beautifulsoup4==4.13.4    # via furo
 black==25.1.0             # via hypofuzz (pyproject.toml), hypothesis
-certifi==2025.4.26        # via requests
+certifi==2025.6.15        # via requests
 charset-normalizer==3.4.2  # via requests
 click==8.1.8              # via black, hypothesis
-coverage==7.8.2           # via hypofuzz (pyproject.toml)
+coverage==7.9.1           # via hypofuzz (pyproject.toml)
 docutils==0.21.2          # via myst-parser, pybtex-docutils, sphinx, sphinxcontrib-bibtex
 exceptiongroup==1.3.0     # via anyio, hypercorn, hypothesis, pytest, taskgroup, trio
 furo==2024.8.6            # via -r deps/docs.in
@@ -22,14 +22,14 @@ h2==4.2.0                 # via hypercorn
 hpack==4.1.0              # via h2
 hypercorn==0.17.3         # via hypofuzz (pyproject.toml)
 hyperframe==6.1.0         # via h2
-hypothesis[cli,watchdog]==6.135.5  # via hypofuzz (pyproject.toml)
+hypothesis[cli,watchdog]==6.135.10  # via hypofuzz (pyproject.toml)
 idna==3.10                # via anyio, requests, trio
 imagesize==1.4.1          # via sphinx
 importlib-metadata==8.7.0  # via sphinx, sphinxcontrib-bibtex
 iniconfig==2.1.0          # via pytest
 jinja2==3.1.6             # via myst-parser, sphinx
 latexcodec==3.0.0         # via pybtex
-libcst==1.8.1             # via hypofuzz (pyproject.toml)
+libcst==1.8.2             # via hypofuzz (pyproject.toml)
 markdown-it-py==3.0.0     # via mdit-py-plugins, myst-parser, rich
 markupsafe==3.0.2         # via jinja2
 mdit-py-plugins==0.4.2    # via myst-parser
@@ -68,7 +68,7 @@ starlette==0.47.0         # via hypofuzz (pyproject.toml)
 taskgroup==0.2.2          # via hypercorn
 tomli==2.2.1              # via black, hypercorn, pytest, sphinx
 trio==0.30.0              # via hypofuzz (pyproject.toml)
-typing-extensions==4.14.0  # via anyio, beautifulsoup4, black, exceptiongroup, hypercorn, rich, starlette, taskgroup
+typing-extensions==4.14.0  # via anyio, beautifulsoup4, black, exceptiongroup, hypercorn, libcst, rich, starlette, taskgroup
 urllib3==2.4.0            # via requests
 watchdog==6.0.0           # via hypothesis
 wsproto==1.2.0            # via hypercorn

--- a/deps/test-old.txt
+++ b/deps/test-old.txt
@@ -7,10 +7,10 @@
 anyio==4.9.0              # via starlette
 attrs==25.3.0             # via hypothesis, outcome, trio
 black==25.1.0             # via hypofuzz (pyproject.toml), hypothesis
-certifi==2025.4.26        # via requests
+certifi==2025.6.15        # via requests
 charset-normalizer==3.4.2  # via requests
 click==8.1.8              # via black, hypothesis
-coverage[toml]==7.8.2     # via hypofuzz (pyproject.toml), pytest-cov
+coverage[toml]==7.9.1     # via hypofuzz (pyproject.toml), pytest-cov
 exceptiongroup==1.3.0     # via anyio, hypercorn, hypothesis, pytest, taskgroup, trio
 execnet==2.1.1            # via pytest-xdist
 h11==0.16.0               # via hypercorn, wsproto
@@ -18,10 +18,10 @@ h2==4.2.0                 # via hypercorn
 hpack==4.1.0              # via h2
 hypercorn==0.17.3         # via hypofuzz (pyproject.toml)
 hyperframe==6.1.0         # via h2
-hypothesis[cli,watchdog]==6.135.5  # via hypofuzz (pyproject.toml)
+hypothesis[cli,watchdog]==6.135.10  # via hypofuzz (pyproject.toml)
 idna==3.10                # via anyio, requests, trio
 iniconfig==2.1.0          # via pytest
-libcst==1.8.1             # via hypofuzz (pyproject.toml)
+libcst==1.8.2             # via hypofuzz (pyproject.toml)
 markdown-it-py==3.0.0     # via rich
 mdurl==0.1.2              # via markdown-it-py
 mypy-extensions==1.1.0    # via black
@@ -29,12 +29,12 @@ outcome==1.3.0.post0      # via trio
 packaging==25.0           # via black, pytest
 pathspec==0.12.1          # via black
 platformdirs==4.3.8       # via black
-pluggy==1.6.0             # via pytest
+pluggy==1.6.0             # via pytest, pytest-cov
 priority==2.0.0           # via hypercorn
 psutil==7.0.0             # via hypofuzz (pyproject.toml)
 pygments==2.19.1          # via rich
 pytest==7.4.4             # via -r /Users/tybug/Desktop/Liam/coding/hypofuzz/deps/test.in, -r deps/test-old.in, hypofuzz (pyproject.toml), pytest-cov, pytest-xdist
-pytest-cov==6.1.1         # via -r /Users/tybug/Desktop/Liam/coding/hypofuzz/deps/test.in
+pytest-cov==6.2.1         # via -r /Users/tybug/Desktop/Liam/coding/hypofuzz/deps/test.in
 pytest-xdist==3.7.0       # via -r /Users/tybug/Desktop/Liam/coding/hypofuzz/deps/test.in
 pyyaml==6.0.2             # via libcst
 requests==2.32.4          # via -r /Users/tybug/Desktop/Liam/coding/hypofuzz/deps/test.in
@@ -45,7 +45,7 @@ starlette==0.47.0         # via hypofuzz (pyproject.toml)
 taskgroup==0.2.2          # via hypercorn
 tomli==2.2.1              # via black, coverage, hypercorn, pytest
 trio==0.30.0              # via hypofuzz (pyproject.toml)
-typing-extensions==4.14.0  # via anyio, black, exceptiongroup, hypercorn, rich, starlette, taskgroup
+typing-extensions==4.14.0  # via anyio, black, exceptiongroup, hypercorn, libcst, rich, starlette, taskgroup
 urllib3==2.4.0            # via requests
 watchdog==6.0.0           # via hypothesis
 wsproto==1.2.0            # via hypercorn

--- a/deps/test.txt
+++ b/deps/test.txt
@@ -7,10 +7,10 @@
 anyio==4.9.0              # via starlette
 attrs==25.3.0             # via hypothesis, outcome, trio
 black==25.1.0             # via hypofuzz (pyproject.toml), hypothesis
-certifi==2025.4.26        # via requests
+certifi==2025.6.15        # via requests
 charset-normalizer==3.4.2  # via requests
 click==8.1.8              # via black, hypothesis
-coverage[toml]==7.8.2     # via hypofuzz (pyproject.toml), pytest-cov
+coverage[toml]==7.9.1     # via hypofuzz (pyproject.toml), pytest-cov
 exceptiongroup==1.3.0     # via anyio, hypercorn, hypothesis, pytest, taskgroup, trio
 execnet==2.1.1            # via pytest-xdist
 h11==0.16.0               # via hypercorn, wsproto
@@ -18,10 +18,10 @@ h2==4.2.0                 # via hypercorn
 hpack==4.1.0              # via h2
 hypercorn==0.17.3         # via hypofuzz (pyproject.toml)
 hyperframe==6.1.0         # via h2
-hypothesis[cli,watchdog]==6.135.5  # via hypofuzz (pyproject.toml)
+hypothesis[cli,watchdog]==6.135.10  # via hypofuzz (pyproject.toml)
 idna==3.10                # via anyio, requests, trio
 iniconfig==2.1.0          # via pytest
-libcst==1.8.1             # via hypofuzz (pyproject.toml)
+libcst==1.8.2             # via hypofuzz (pyproject.toml)
 markdown-it-py==3.0.0     # via rich
 mdurl==0.1.2              # via markdown-it-py
 mypy-extensions==1.1.0    # via black
@@ -29,12 +29,12 @@ outcome==1.3.0.post0      # via trio
 packaging==25.0           # via black, pytest
 pathspec==0.12.1          # via black
 platformdirs==4.3.8       # via black
-pluggy==1.6.0             # via pytest
+pluggy==1.6.0             # via pytest, pytest-cov
 priority==2.0.0           # via hypercorn
 psutil==7.0.0             # via hypofuzz (pyproject.toml)
 pygments==2.19.1          # via pytest, rich
 pytest==8.4.0             # via -r deps/test.in, hypofuzz (pyproject.toml), pytest-cov, pytest-xdist
-pytest-cov==6.1.1         # via -r deps/test.in
+pytest-cov==6.2.1         # via -r deps/test.in
 pytest-xdist==3.7.0       # via -r deps/test.in
 pyyaml==6.0.2             # via libcst
 requests==2.32.4          # via -r deps/test.in
@@ -45,7 +45,7 @@ starlette==0.47.0         # via hypofuzz (pyproject.toml)
 taskgroup==0.2.2          # via hypercorn
 tomli==2.2.1              # via black, coverage, hypercorn, pytest
 trio==0.30.0              # via hypofuzz (pyproject.toml)
-typing-extensions==4.14.0  # via anyio, black, exceptiongroup, hypercorn, rich, starlette, taskgroup
+typing-extensions==4.14.0  # via anyio, black, exceptiongroup, hypercorn, libcst, rich, starlette, taskgroup
 urllib3==2.4.0            # via requests
 watchdog==6.0.0           # via hypothesis
 wsproto==1.2.0            # via hypercorn

--- a/src/hypofuzz/bayes.py
+++ b/src/hypofuzz/bayes.py
@@ -1,0 +1,31 @@
+import math
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from hypofuzz.hypofuzz import FuzzTarget
+
+
+def behaviors_per_input(target: "FuzzTarget") -> float:
+    # an estimator for the number of behaviors the next input will discover.
+    since = target.provider.since_new_branch
+    return (1 / since) if since > 0 else 1
+
+
+def behaviors_per_second(target: "FuzzTarget") -> float:
+    # an estimator for the number of behaviors discovered per second, assuming
+    # one process is fuzzing this target continuously over that second.
+    # This is a simple adjustment of behaviors_per_input for the test runtime.
+    ninputs = target.provider.ninputs
+    elapsed_time = target.provider.elapsed_time
+
+    if elapsed_time == 0:
+        return 1
+
+    inputs_per_second = ninputs / elapsed_time
+    return behaviors_per_input(target) * inputs_per_second
+
+
+def softmax(values: list[float]) -> list[float]:
+    # subtract max for numerical stability
+    softmaxed = [math.exp(value - max(values)) for value in values]
+    return [value / sum(softmaxed) for value in softmaxed]

--- a/src/hypofuzz/bayes.py
+++ b/src/hypofuzz/bayes.py
@@ -4,6 +4,10 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from hypofuzz.hypofuzz import FuzzTarget
 
+# for the behaviors estimators, we should incorporate a lookback across the
+# history of workers for this test. Give higher weight to newer estimators
+# (proportional to their confidence ie sample size).
+
 
 def behaviors_per_input(target: "FuzzTarget") -> float:
     # an estimator for the number of behaviors the next input will discover.
@@ -26,6 +30,11 @@ def behaviors_per_second(target: "FuzzTarget") -> float:
 
 
 def softmax(values: list[float]) -> list[float]:
+    if not values:
+        return []
     # subtract max for numerical stability
-    softmaxed = [math.exp(value - max(values)) for value in values]
-    return [value / sum(softmaxed) for value in softmaxed]
+    max_value = max(values)
+    softmaxed = [math.exp(value - max_value) for value in values]
+
+    total = sum(softmaxed)
+    return [value / total for value in softmaxed]

--- a/src/hypofuzz/hypofuzz.py
+++ b/src/hypofuzz/hypofuzz.py
@@ -301,6 +301,9 @@ class FuzzProcess:
             estimators = softmax(estimators)
             target = self.random.choices(self.targets, weights=estimators, k=1)[0]
 
+            # TODO we should scale this up we our estimator expects that it will
+            # take a long time to discover a new behavior, to reduce the overhead
+            # of switching.
             for _ in range(100):
                 target.run_one()
 

--- a/src/hypofuzz/hypofuzz.py
+++ b/src/hypofuzz/hypofuzz.py
@@ -1,7 +1,6 @@
 """Adaptive fuzzing for property-based tests using Hypothesis."""
 
 import contextlib
-import itertools
 import math
 from collections import defaultdict
 from collections.abc import Callable
@@ -36,8 +35,8 @@ from hypothesis.internal.reflection import (
     get_pretty_function_description,
     get_signature,
 )
-from sortedcontainers import SortedKeyList
 
+from hypofuzz.bayes import behaviors_per_second, softmax
 from hypofuzz.collection import collect_tests
 from hypofuzz.corpus import (
     get_shrinker,
@@ -265,9 +264,7 @@ class FuzzProcess:
 
     def __init__(self, targets: list[FuzzTarget]) -> None:
         self.random = Random()
-        self.targets: SortedKeyList[FuzzTarget, int] = SortedKeyList(
-            targets, lambda p: p.provider.since_new_branch
-        )
+        self.targets = targets
 
         dispatch: dict[bytes, list[FuzzTarget]] = defaultdict(list)
         for target in targets:
@@ -289,32 +286,23 @@ class FuzzProcess:
         # TODO: make this aware of test runtime, so it adapts for behaviors-per-second
         #       rather than behaviors-per-input.
 
-        resort = False
-        for count in itertools.count():
-            if count % 20 == 0:
-                resort = True
-                i = self.random.randrange(len(self.targets))
-            else:
-                i = 0
-            target = self.targets[i]
-            target.run_one()
-            if target.has_found_failure:
-                print(f"found failing example for {target.nodeid}")
-                self.targets.pop(i)
-
-            if self.targets and (
-                resort
-                or (
-                    len(self.targets) > 1
-                    and self.targets.key(self.targets[0])
-                    > self.targets.key(self.targets[1])
-                )
-            ):
-                # pay our log-n cost to keep the list sorted
-                self.targets.add(self.targets.pop(0))
+        while True:
+            for target in self.targets:
+                if target.has_found_failure:
+                    print(f"found failing example for {target.nodeid}")
+                    self.targets.remove(target)
 
             if not self.targets:
-                return
+                break
+
+            # choose the next target to fuzz with probability equal to the softmax
+            # of its estimator.
+            estimators = [behaviors_per_second(target) for target in self.targets]
+            estimators = softmax(estimators)
+            target = self.random.choices(self.targets, weights=estimators, k=1)[0]
+
+            for _ in range(100):
+                target.run_one()
 
 
 def _fuzz(pytest_args: tuple[str, ...], nodeids: list[str]) -> None:

--- a/tests/test_bayes.py
+++ b/tests/test_bayes.py
@@ -1,3 +1,4 @@
+import pytest
 from hypothesis import given, note, strategies as st
 
 from hypofuzz.bayes import softmax
@@ -19,3 +20,6 @@ def test_softmax(values):
             assert softmaxed[i] <= softmaxed[i + 1]
         if values[i] > values[i + 1]:
             assert softmaxed[i] >= softmaxed[i + 1]
+
+    if values:
+        assert sum(softmaxed) == pytest.approx(1)

--- a/tests/test_bayes.py
+++ b/tests/test_bayes.py
@@ -1,0 +1,21 @@
+from hypothesis import given, note, strategies as st
+
+from hypofuzz.bayes import softmax
+
+
+@given(st.lists(st.floats(min_value=0, allow_nan=False, allow_infinity=False)))
+def test_softmax(values):
+    softmaxed = softmax(values)
+    note(f"{softmaxed=}")
+    assert all(0 <= v <= 1 for v in softmaxed)
+
+    # check that softmax preserves ordering
+    for i in range(len(values) - 1):
+        if values[i] == values[i + 1]:
+            assert softmaxed[i] == softmaxed[i + 1]
+        if values[i] < values[i + 1]:
+            # note <= and not < here, since softmax may round down small
+            # differences in values to 0
+            assert softmaxed[i] <= softmaxed[i + 1]
+        if values[i] > values[i + 1]:
+            assert softmaxed[i] >= softmaxed[i + 1]


### PR DESCRIPTION
I don't want to go all the way to thompson sampling yet, but softmax should be better than the current epsilon-greedy, especially when our estimators are as unstable as they are

Also improves our estimator to "behaviors per second" instead of "behaviors per input", and batches targets by 100 inputs instead of 1