### PR TITLE
Try testing against pytest 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        toxenv: ["test", "pytest7"]
+        toxenv: ["test", "pytest6", "pytest7"]
       fail-fast: false
     steps:
     - uses: actions/checkout@v4

--- a/src/hypofuzz/coverage.py
+++ b/src/hypofuzz/coverage.py
@@ -186,9 +186,6 @@ class CoverageCollector:
         # if anything is None, skip this branch. This can happen for various reasons.
         # Most notably with -X no_debug_ranges, in which case we will get *zero*
         # position information.
-        # TODO detect when python is running with no_debug_ranges and warn or error?
-        #
-        # see https://docs.python.org/3/reference/datamodel.html#codeobject.co_positions.
         if (
             s_start_line is None
             or d_start_line is None

--- a/src/hypofuzz/database.py
+++ b/src/hypofuzz/database.py
@@ -332,7 +332,9 @@ class ReportWithDiff(Report):
     timestamp_monotonic: float
 
     def __post_init__(self) -> None:
-        assert all(count >= 0 for count in self.status_counts_diff.values())
+        assert all(
+            count >= 0 for count in self.status_counts_diff.values()
+        ), self.status_counts_diff
         assert self.elapsed_time_diff >= 0.0
         assert self.timestamp_monotonic >= 0.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,13 +23,14 @@ commands =
     pip install --editable .
     sphinx-build -W --keep-going src/hypofuzz/docs {env:HYPOFUZZ_DOCS_OUTPUT_DIR:docs/docs} {posargs}
 
-[testenv:{test,pytest7}]
+[testenv:{test,pytest6,pytest7}]
 description = Runs pytest with posargs - `tox -e test -- -v` == `pytest -v`
 deps =
-    test:     --requirement deps/test.txt
-    pytest7: --requirement deps/test-old.txt
+    --requirement deps/test.txt
 commands =
     pip install --editable .
+    pytest6: pip install --upgrade pytest~=6.0
+    pytest7: pip install --upgrade pytest~=7.0
     pytest {posargs:-n auto}
 
 [testenv:deps]


### PR DESCRIPTION
let's see how bad this will be to support; I'm tempted to drop it, pytest 7 was 3 years ago, and [download stats](https://pepy.tech/projects/pytest?timeRange=threeMonths&category=version&includeCIDownloads=true&granularity=daily&viewType=line&versions=8.*%2C7.*%2C6.*) looks like about 5% usage