### PR TITLE
Add "fixed" failure state, and update dashboard failures properly

### DIFF
--- a/src/hypofuzz/corpus.py
+++ b/src/hypofuzz/corpus.py
@@ -21,7 +21,7 @@ from hypothesis.internal.conjecture.shrinker import Shrinker, sort_key as _sort_
 from hypothesis.internal.escalation import InterestingOrigin
 from hypothesis.internal.observability import TestCaseObservation
 
-from hypofuzz.database import ChoicesT, HypofuzzDatabase, Observation
+from hypofuzz.database import ChoicesT, FailureState, HypofuzzDatabase, Observation
 
 if TYPE_CHECKING:
     from typing import TypeAlias
@@ -240,7 +240,7 @@ class Corpus:
                     self.database_key,
                     choices,
                     Observation.from_hypothesis(observation),
-                    shrunk=False,
+                    state=FailureState.UNSHRUNK,
                 )
 
                 if previous is not None:
@@ -252,8 +252,7 @@ class Corpus:
                     self._db.delete_failure(
                         self.database_key,
                         previous_choices,
-                        Observation.from_hypothesis(previous),
-                        shrunk=False,
+                        state=FailureState.UNSHRUNK,
                     )
                 return True
 

--- a/src/hypofuzz/hypofuzz.py
+++ b/src/hypofuzz/hypofuzz.py
@@ -44,6 +44,7 @@ from hypofuzz.corpus import (
 from hypofuzz.database import (
     ChoicesT,
     DatabaseEvent,
+    FailureState,
     HypofuzzDatabase,
     Observation,
     Phase,
@@ -198,13 +199,15 @@ class FuzzTarget:
             # move this failure from the unshrunk to the shrunk key.
             assert observation is not None
             self.database.delete_failure(
-                self.database_key, shrinker.choices, observation=None, shrunk=False
+                self.database_key,
+                shrinker.choices,
+                state=FailureState.UNSHRUNK,
             )
             self.database.save_failure(
                 self.database_key,
                 shrinker.choices,
                 Observation.from_hypothesis(observation),
-                shrunk=True,
+                state=FailureState.SHRUNK,
             )
 
         # NOTE: this distillation logic works fine, it's just discovering new coverage

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -86,6 +86,6 @@ def test_dashboard_failure(tmp_path):
         # but if we run the worker again, the failure disappears
         with fuzz(test_dir):
             wait_for(
-                lambda: (dash.state()["test_a.py::test_maybe_fail"]["failure"] is None),
+                lambda: dash.state()["test_a.py::test_maybe_fail"]["failure"] is None,
                 interval=0.25,
             )

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -8,7 +8,7 @@ from hypothesis.database import (
     choices_from_bytes,
 )
 
-from hypofuzz.database import HypofuzzDatabase, Phase, test_keys_key
+from hypofuzz.database import FailureState, HypofuzzDatabase, Phase, test_keys_key
 from hypofuzz.hypofuzz import FuzzTarget
 
 
@@ -103,7 +103,7 @@ def test_adds_failures_to_database():
     for _ in range(500):
         process.run_one()
 
-    failures = list(db.fetch_failures(process.database_key, shrunk=True))
+    failures = list(db.fetch_failures(process.database_key, state=FailureState.SHRUNK))
     failures_hypothesis = list(db._db.fetch(process.database_key))
     assert len(failures) == 1
     assert len(failures_hypothesis) == 1
@@ -111,7 +111,9 @@ def test_adds_failures_to_database():
     assert choices_from_bytes(failures_hypothesis[0]) == (10,)
 
     # we should have fully shrunk the failure
-    assert not list(db.fetch_failures(process.database_key, shrunk=False))
+    assert not list(
+        db.fetch_failures(process.database_key, state=FailureState.UNSHRUNK)
+    )
 
 
 def test_database_keys_incorporate_parametrization(tmp_path):

--- a/tests/test_fuzz_process.py
+++ b/tests/test_fuzz_process.py
@@ -6,7 +6,7 @@ from hypothesis import given, strategies as st
 from hypothesis.database import InMemoryExampleDatabase
 from hypothesis.internal.conjecture.data import Status
 
-from hypofuzz.database import HypofuzzDatabase
+from hypofuzz.database import FailureState, HypofuzzDatabase
 from hypofuzz.hypofuzz import FuzzTarget
 
 
@@ -43,9 +43,11 @@ def test_fuzz_one_process_explain_mode():
         fp.run_one()
 
     assert fp.provider.status_counts[Status.INTERESTING] == 1
-    failures = list(db.fetch_failures(fp.database_key, shrunk=True))
+    failures = list(db.fetch_failures(fp.database_key, state=FailureState.SHRUNK))
     assert len(failures) == 1
-    observation = db.fetch_failure_observation(fp.database_key, failures[0])
+    observation = db.fetch_failure_observation(
+        fp.database_key, failures[0], state=FailureState.SHRUNK
+    )
     assert "CustomError" in observation.metadata.traceback
     expected = textwrap.dedent(
         """


### PR DESCRIPTION
Currently, we avoid deleting fixed failures from the shrunk or unshrunk keys if it's been more than 8 days. As a result, these failures persist in the dashboard (even across restarts), because the dashboard does not know the failure has been fixed. 

This PR adds a third state `fixed` to the two current `shrunk` and `unshrunk` states. Failures are downgraded to `fixed` by workers, and removed from `fixed` if 8 days have passed. The dashboard only reads failures from the `shrunk` and `unshrunk` states.

---

Separately, our in-memory updating of dashboard failures never worked, because the database event keys were not parsing correctly. This PR also fixes that and formalizes the database keys a bit more.