### PR TITLE
Refactor to support multiple failures

### DIFF
--- a/src/hypofuzz/dashboard/api.py
+++ b/src/hypofuzz/dashboard/api.py
@@ -7,6 +7,7 @@ from starlette.responses import JSONResponse, Response
 from starlette.routing import Route
 
 from hypofuzz.dashboard.models import (
+    dashboard_failures,
     dashboard_observation,
     dashboard_report,
     dashboard_test,
@@ -126,7 +127,7 @@ async def api_backing_state_tests(request: Request) -> Response:
         nodeid: {
             "database_key": test.database_key,
             "nodeid": test.nodeid,
-            "failure": test.failure,
+            "failures": dashboard_failures(test.failures),
             "reports_by_worker": {
                 worker_uuid: [dashboard_report(report) for report in reports]
                 for worker_uuid, reports in test.reports_by_worker.items()

--- a/src/hypofuzz/dashboard/test.py
+++ b/src/hypofuzz/dashboard/test.py
@@ -6,6 +6,7 @@ from hypothesis.internal.cache import LRUCache
 
 from hypofuzz.compat import bisect_right
 from hypofuzz.database import (
+    FailureState,
     Observation,
     Phase,
     Report,
@@ -24,7 +25,7 @@ class Test:
     nodeid: str
     rolling_observations: list[Observation]
     corpus_observations: list[Observation]
-    failure: Optional[Observation]
+    failures: dict[str, tuple[FailureState, Observation]]
     reports_by_worker: dict[str, list[ReportWithDiff]]
 
     linear_reports: list[ReportWithDiff] = field(init=False)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -49,20 +49,21 @@ def test_dashboard_failure(tmp_path):
     )
 
     with dashboard(test_path=test_dir) as dash:
-        assert dash.state()["test_a.py::test_maybe_fail"]["failure"] is None
+        assert dash.state()["test_a.py::test_maybe_fail"]["failures"] == {}
         with fuzz(test_dir):
             wait_for(
-                lambda: (
-                    dash.state()["test_a.py::test_maybe_fail"]["failure"] is not None
-                ),
+                lambda: dash.state()["test_a.py::test_maybe_fail"]["failures"],
                 interval=0.25,
             )
 
     # if we restart the dasbhoard, the failure is still shown
     with dashboard(test_path=test_dir) as dash:
-        failure = dash.state()["test_a.py::test_maybe_fail"]["failure"]
-        assert failure is not None
-        assert failure["property"] == "test_a.py::test_maybe_fail"
+        failures = dash.state()["test_a.py::test_maybe_fail"]["failures"]
+        assert len(failures) == 1
+        failure = list(failures.values())[0]
+        assert failure["observation"]["property"] == "test_a.py::test_maybe_fail"
+        # TODO wait for shrinking to finish? or put that into a separate test?
+        assert failure["state"] in ["unshrunk", "shrunk"]
 
     # and also if we change the code to pass, but don't run the worker again, the
     # failure is still shown
@@ -79,13 +80,15 @@ def test_dashboard_failure(tmp_path):
         """,
     )
     with dashboard(test_path=test_dir) as dash:
-        failure = dash.state()["test_a.py::test_maybe_fail"]["failure"]
-        assert failure is not None
-        assert failure["property"] == "test_a.py::test_maybe_fail"
+        failures = dash.state()["test_a.py::test_maybe_fail"]["failures"]
+        assert len(failures) == 1
+        failure = list(failures.values())[0]
+        assert failure["observation"]["property"] == "test_a.py::test_maybe_fail"
+        assert failure["state"] in ["unshrunk", "shrunk"]
 
         # but if we run the worker again, the failure disappears
         with fuzz(test_dir):
             wait_for(
-                lambda: dash.state()["test_a.py::test_maybe_fail"]["failure"] is None,
+                lambda: dash.state()["test_a.py::test_maybe_fail"]["failures"] == {},
                 interval=0.25,
             )

--- a/tests/test_linearize.py
+++ b/tests/test_linearize.py
@@ -166,7 +166,7 @@ def _test_for_reports(reports, *, database_key: bytes = b"", nodeid: str = "") -
         rolling_observations=[],
         corpus_observations=[],
         reports_by_worker=reports_by_worker,
-        failure=None,
+        failures={},
     )
     test._check_invariants()
     return test


### PR DESCRIPTION
This is the groundwork for displaying multiple failures. There's a bunch of dashboard.py code refactoring (some only tangentially related). Does not yet address most of the items in https://github.com/Zac-HD/hypofuzz/issues/98.