### PR TITLE
Display shrinking state

### DIFF
--- a/src/hypofuzz/frontend/src/components/TestStatusPill.tsx
+++ b/src/hypofuzz/frontend/src/components/TestStatusPill.tsx
@@ -1,6 +1,6 @@
 import { TestStatus } from "../types/dashboard"
 
-export function StatusPill({ status }: { status: TestStatus }) {
+export function TestStatusPill({ status }: { status: TestStatus }) {
   return (
     <span style={{ textAlign: "center" }}>
       {status === TestStatus.FAILED ? (

--- a/src/hypofuzz/frontend/src/components/TestTable.tsx
+++ b/src/hypofuzz/frontend/src/components/TestTable.tsx
@@ -12,7 +12,7 @@ import { Link } from "react-router-dom"
 
 import { Status, Test } from "../types/dashboard"
 import { getTestStats, inputsPerSecond } from "../utils/testStats"
-import { StatusPill } from "./StatusPill"
+import { TestStatusPill } from "./TestStatusPill"
 import { Table } from "./Table"
 import { Tooltip } from "./Tooltip"
 
@@ -129,7 +129,7 @@ export function TestTable({ tests, onFilterChange }: Props) {
         {test.nodeid}
       </Link>,
       <div style={{ textAlign: "center" }}>
-        <StatusPill status={test.status} />
+        <TestStatusPill status={test.status} />
       </div>,
       <div style={{ textAlign: "right", fontVariantNumeric: "tabular-nums" }}>
         {stats.inputs}
@@ -165,7 +165,7 @@ export function TestTable({ tests, onFilterChange }: Props) {
           >
             {test.nodeid}
           </Link>
-          <StatusPill status={test.status} />
+          <TestStatusPill status={test.status} />
         </div>
         <div className="table__mobile-row__statistics">
           <InlineStatistic icon={iconInputs} value={stats.inputs} />

--- a/src/hypofuzz/frontend/src/pages/Test.tsx
+++ b/src/hypofuzz/frontend/src/pages/Test.tsx
@@ -17,7 +17,7 @@ import { Link, useParams } from "react-router-dom"
 
 import { Collapsible } from "../components/Collapsible"
 import { CoverageGraph } from "../components/CoverageGraph"
-import { StatusPill } from "../components/StatusPill"
+import { TestStatusPill } from "../components/TestStatusPill"
 import { Table } from "../components/Table"
 import { TestPatches } from "../components/TestPatches"
 import { Tooltip } from "../components/Tooltip"
@@ -30,12 +30,30 @@ import { reHighlight } from "../utils/utils"
 
 hljs.registerLanguage("python", python)
 
-function FailureRow({ failure }: { failure: Failure }) {
+function FailureStatusPill({ failure }: { failure: Failure }) {
   return (
-    <div className="test-failure">
-      <h2>Failure</h2>
-      <div className="test-failure__item">
-        <h3>Call</h3>
+    <span style={{ textAlign: "center" }}>
+      {failure.state === "shrunk" ? (
+        <span className="pill pill__neutral">Fully shrunk</span>
+      ) : failure.state === "unshrunk" ? (
+        <span className="pill pill__neutral">Still shrinking...</span>
+      ) : (
+        // this case shouldn't happen
+        <></>
+      )}
+    </span>
+  )
+}
+
+function FailureCard({ failure }: { failure: Failure }) {
+  return (
+    <div className="card">
+      <div style={{ display: "flex", alignItems: "center", gap: "0.7rem", marginBottom: "1rem" }}>
+        <div className="failure__title">Failure</div>
+        <FailureStatusPill failure={failure} />
+      </div>
+      <div className="failure__item">
+        <div className="failure__item__subtitle">Call</div>
         <pre>
           <code className="language-python">
             {failure.observation.metadata.get("reproduction_decorator") +
@@ -43,7 +61,7 @@ function FailureRow({ failure }: { failure: Failure }) {
               failure.observation.representation}
           </code>
         </pre>
-        <h3>Traceback</h3>
+        <div className="failure__item__subtitle">Traceback</div>
         <pre>
           <code className="language-python">
             {failure.observation.metadata.get("traceback")}
@@ -171,7 +189,7 @@ export function TestPage() {
           >
             {nodeid}
           </span>
-          <StatusPill status={test.status} />
+          <TestStatusPill status={test.status} />
         </div>
         <div style={{ paddingTop: "1rem", paddingBottom: "1rem" }}>
           <Table
@@ -200,7 +218,7 @@ export function TestPage() {
       </div>
       <CoverageGraph tests={new Map([[nodeid, test]])} />
       {Array.from(test.failures.values()).map(failure => (
-        <FailureRow failure={failure} />
+        <FailureCard failure={failure} />
       ))}
       <Tyche test={test} />
       {nodeidsWithPatches?.includes(nodeid) && (

--- a/src/hypofuzz/frontend/src/styles/styles.scss
+++ b/src/hypofuzz/frontend/src/styles/styles.scss
@@ -593,24 +593,20 @@ $mobile-breakpoint: 768px;
     }
 }
 
-.test-failure {
-    margin: 20px 0;
-    padding: 20px;
-    background: white;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-
-    h2 {
-        margin-bottom: 20px;
+.failure {
+    &__title {
+        font-size: 1.5rem;
+        font-weight: bold;
         color: #e74c3c;
     }
 
     &__item {
         margin-bottom: 30px;
 
-        h3 {
-            margin: 15px 0 10px;
+        &__subtitle {
+            font-weight: bold;
             font-size: 1.1em;
+            margin: 15px 0 10px;
             color: #2c3e50;
         }
 


### PR DESCRIPTION
Went with "Fully shrunk" and "Still shrinking..." for now, we can adjust text easily later

Preview (ignore "null", that's fixed by https://github.com/HypothesisWorks/hypothesis/pull/4445):

<img width="518" alt="image" src="https://github.com/user-attachments/assets/060d6f07-4c50-4f02-908f-759a5c2b91fd" />

