### PR TITLE
Track and show fatal failures

### DIFF
--- a/src/hypofuzz/dashboard/models.py
+++ b/src/hypofuzz/dashboard/models.py
@@ -55,6 +55,7 @@ class DashboardTest(TypedDict):
     rolling_observations: list[DashboardObservation]
     corpus_observations: list[DashboardObservation]
     failures: dict[str, Failure]
+    fatal_failure: Optional[str]
     reports_by_worker: dict[str, list[DashboardReport]]
 
 
@@ -84,6 +85,7 @@ class AddTestsTest(TypedDict):
     database_key: str
     nodeid: str
     failures: dict[str, Failure]
+    fatal_failure: Optional[str]
 
 
 @dataclass
@@ -188,6 +190,7 @@ def dashboard_test(test: Test) -> DashboardTest:
             dashboard_observation(obs) for obs in test.corpus_observations
         ],
         "failures": dashboard_failures(test.failures),
+        "fatal_failure": test.fatal_failure,
         "reports_by_worker": {
             worker_uuid: [dashboard_report(report) for report in reports]
             for worker_uuid, reports in test.reports_by_worker.items()

--- a/src/hypofuzz/dashboard/test.py
+++ b/src/hypofuzz/dashboard/test.py
@@ -26,6 +26,7 @@ class Test:
     rolling_observations: list[Observation]
     corpus_observations: list[Observation]
     failures: dict[str, tuple[FailureState, Observation]]
+    fatal_failure: Optional[str]
     reports_by_worker: dict[str, list[ReportWithDiff]]
 
     linear_reports: list[ReportWithDiff] = field(init=False)
@@ -97,7 +98,10 @@ class Test:
         )
 
         for worker_uuid, reports in self.reports_by_worker.items():
-            assert {r.nodeid for r in reports} == {self.nodeid}
+            assert {r.nodeid for r in reports} == {self.nodeid}, (
+                self.nodeid,
+                {r.nodeid for r in reports},
+            )
             assert {r.database_key for r in reports} == {self.database_key}
             assert {r.worker_uuid for r in reports} == {worker_uuid}
             self._assert_reports_ordered(self.linear_reports, ["timestamp_monotonic"])

--- a/src/hypofuzz/dashboard/websocket.py
+++ b/src/hypofuzz/dashboard/websocket.py
@@ -116,6 +116,7 @@ class OverviewWebsocket(HypofuzzWebsocket):
                     "database_key": test.database_key,
                     "nodeid": test.nodeid,
                     "failures": dashboard_failures(test.failures),
+                    "fatal_failure": test.fatal_failure,
                 }
                 for test in tests.copy().values()
             ],
@@ -159,6 +160,7 @@ class TestWebsocket(HypofuzzWebsocket):
                     "database_key": test.database_key,
                     "nodeid": test.nodeid,
                     "failures": dashboard_failures(test.failures),
+                    "fatal_failure": test.fatal_failure,
                 }
             ],
         )

--- a/src/hypofuzz/frontend/src/components/TestStatusPill.tsx
+++ b/src/hypofuzz/frontend/src/components/TestStatusPill.tsx
@@ -3,7 +3,9 @@ import { TestStatus } from "src/types/dashboard"
 export function TestStatusPill({ status }: { status: TestStatus }) {
   return (
     <span style={{ textAlign: "center" }}>
-      {status === TestStatus.FAILED ? (
+      {status === TestStatus.FAILED_FATALLY ? (
+        <span className="pill pill__failure">Failed fatally</span>
+      ) : status === TestStatus.FAILED ? (
         <span className="pill pill__failure">Failed</span>
       ) : status === TestStatus.SHRINKING ? (
         <span className="pill pill__warning">Shrinking</span>

--- a/src/hypofuzz/frontend/src/context/DataProvider.tsx
+++ b/src/hypofuzz/frontend/src/context/DataProvider.tsx
@@ -54,6 +54,7 @@ type TestsAction =
         database_key: string
         nodeid: string
         failures: Map<string, Failure>
+        fatal_failure: string | null
       }[]
     }
   | {
@@ -129,7 +130,7 @@ function testsReducer(
     if (newState.has(nodeid)) {
       return newState.get(nodeid)!
     } else {
-      const test = new Test(null, nodeid, [], [], new Map(), new Map())
+      const test = new Test(null, nodeid, [], [], new Map(), null, new Map())
       newState.set(test.nodeid, test)
       return test
     }
@@ -142,12 +143,13 @@ function testsReducer(
 
     case DashboardEventType.ADD_TESTS: {
       const { tests } = action
-      for (const { database_key, nodeid, failures } of tests) {
+      for (const { database_key, nodeid, failures, fatal_failure } of tests) {
         const test = getOrCreateTest(nodeid)
         test.database_key = database_key
         failures.forEach((failure, interesting_origin) => {
           test.failures.set(interesting_origin, failure)
         })
+        test.fatal_failure = fatal_failure
       }
       return newState
     }
@@ -272,6 +274,7 @@ export function DataProvider({ children }: DataProviderProps) {
                   database_key: testData.database_key,
                   nodeid: nodeid,
                   failures: testData.failures,
+                  fatal_failure: testData.fatal_failure,
                 },
               ],
             })
@@ -397,6 +400,7 @@ export function DataProvider({ children }: DataProviderProps) {
                   Failure.fromJson(value),
                 ]),
               ),
+              fatal_failure: test.fatal_failure,
             })),
           })
           break

--- a/src/hypofuzz/frontend/src/pages/Test.tsx
+++ b/src/hypofuzz/frontend/src/pages/Test.tsx
@@ -78,6 +78,22 @@ function FailureCard({ failure }: { failure: Failure }) {
   )
 }
 
+function FatalFailureCard({ failure }: { failure: string }) {
+  return (
+    <div className="card">
+      <div className="failure__title">Fatal failure</div>
+      <div className="failure__item">
+        <div className="failure__item__subtitle">Traceback</div>
+        <pre>
+          <code className="language-python" style={{ whiteSpace: "pre-wrap" }}>
+            {failure}
+          </code>
+        </pre>
+      </div>
+    </div>
+  )
+}
+
 export function TestPage() {
   const { nodeid } = useParams<{ nodeid: string }>()
   const { tests, testsLoaded } = useData(nodeid)
@@ -230,6 +246,7 @@ export function TestPage() {
       {Array.from(test.failures.values()).map(failure => (
         <FailureCard failure={failure} />
       ))}
+      {test.fatal_failure && <FatalFailureCard failure={test.fatal_failure} />}
       <Tyche test={test} />
       {nodeidsWithPatches?.includes(nodeid) && (
         <div className="card">

--- a/src/hypofuzz/frontend/src/types/dashboard.ts
+++ b/src/hypofuzz/frontend/src/types/dashboard.ts
@@ -189,8 +189,9 @@ export class Observation extends Dataclass<Observation> {
 }
 
 export enum TestStatus {
-  FAILED = 0,
-  SHRINKING = 1,
-  RUNNING = 2,
-  WAITING = 3,
+  FAILED_FATALLY = 0,
+  FAILED = 1,
+  SHRINKING = 2,
+  RUNNING = 3,
+  WAITING = 4,
 }

--- a/src/hypofuzz/frontend/src/types/test.ts
+++ b/src/hypofuzz/frontend/src/types/test.ts
@@ -53,6 +53,7 @@ export class Test extends Dataclass<Test> {
     public rolling_observations: Observation[],
     public corpus_observations: Observation[],
     public failures: Map<string, Failure>,
+    public fatal_failure: string | null,
     public reports_by_worker: Map<string, Report[]>,
   ) {
     super()
@@ -91,6 +92,7 @@ export class Test extends Dataclass<Test> {
           Failure.fromJson(value),
         ]),
       ),
+      data.fatal_failure,
       new Map(
         Object.entries(data.reports_by_worker).map(([key, value]) => [
           key,
@@ -196,6 +198,9 @@ export class Test extends Dataclass<Test> {
   }
 
   get status() {
+    if (this.fatal_failure) {
+      return TestStatus.FAILED_FATALLY
+    }
     if (this.failures.size > 0) {
       return TestStatus.FAILED
     }

--- a/src/hypofuzz/provider.py
+++ b/src/hypofuzz/provider.py
@@ -269,6 +269,9 @@ class HypofuzzProvider(PrimitiveProvider):
         self.db.save(test_keys_key, self.database_key)
         # save the worker identity once at startup
         self.db.save_worker_identity(self.database_key, self.worker_identity)
+        # clear out any fatal failures now that we've successfully started this
+        # test
+        self.db.delete_fatal_failures(self.database_key)
 
         if not self._replay_queue:
             # if no worker has ever worked on this test before, save an initial

--- a/tests/test_linearize.py
+++ b/tests/test_linearize.py
@@ -167,6 +167,7 @@ def _test_for_reports(reports, *, database_key: bytes = b"", nodeid: str = "") -
         corpus_observations=[],
         reports_by_worker=reports_by_worker,
         failures={},
+        fatal_failure=None,
     )
     test._check_invariants()
     return test


### PR DESCRIPTION
If a strategy is constructed incorrectly, like referencing a missing fixture, it will fail at runtime. We don't want the entire worker to go down when that happens. In this pull we track a singleton failure per test when that happens, and show the traceback on the dashboard in a similar (but separate) card to normal failures.