### PR TITLE
Add support for unittest and class-based pytest

### DIFF
--- a/src/hypofuzz/detection.py
+++ b/src/hypofuzz/detection.py
@@ -1,5 +1,5 @@
 #: |in_hypofuzz_run| is ``True`` when HypoFuzz has been invoked via
 #: ``hypothesis fuzz`` or another entrypoint, and ``False`` otherwise. You can
 #: use this to check whether HypoFuzz is currently fuzzing (or about to
-#: start fuzzing).
+#: start fuzzing), as opposed to just being imported.
 in_hypofuzz_run: bool = False

--- a/src/hypofuzz/hypofuzz.py
+++ b/src/hypofuzz/hypofuzz.py
@@ -155,7 +155,7 @@ class FuzzTarget:
     def _new_state(
         self, *, extra_kwargs: Optional[dict[str, Any]] = None
     ) -> HypofuzzStateForActualGivenExecution:
-        arguments = []
+        arguments: list[Any] = []
 
         if self.pytest_item is not None and isinstance(self.pytest_item.parent, Class):
             assert self._pytest_item_instance is not None
@@ -237,7 +237,7 @@ class FuzzTarget:
                 extra_kwargs[name] = request.getfixturevalue(name)
 
         if isinstance(self.pytest_item.parent, Class):
-            self._pytest_item_instance = self.pytest_item.parent.newinstance()
+            self._pytest_item_instance = self.pytest_item.parent.newinstance()  # type: ignore
 
         if isinstance(self.pytest_item, TestCaseFunction):
             assert self._pytest_item_instance is not None

--- a/tests/common.py
+++ b/tests/common.py
@@ -287,6 +287,7 @@ def write_test_code(path: Path, db_dir, code: str) -> None:
             from hypothesis import given, settings, strategies as st, HealthCheck, target
             from hypothesis.database import DirectoryBasedExampleDatabase
             import pytest
+            from unittest import TestCase
 
             settings.register_profile("testing", settings(database=DirectoryBasedExampleDatabase("{db_dir}")))
             settings.load_profile("testing")
@@ -346,7 +347,6 @@ def collect(code: str) -> CollectionResult:
 
 def collect_names(code: str) -> set[str]:
     return {fp.test_fn.__name__ for fp in collect(code).fuzz_targets}
-
 
 
 def assert_no_failures(db, key):

--- a/tests/common.py
+++ b/tests/common.py
@@ -15,11 +15,12 @@ from queue import Queue
 from typing import Optional
 
 import requests
+from hypothesis.database import DirectoryBasedExampleDatabase
 from hypothesis.internal.escalation import InterestingOrigin
 from hypothesis.internal.reflection import get_pretty_function_description
 
 from hypofuzz.collection import CollectionResult, collect_tests
-from hypofuzz.database import test_keys_key
+from hypofuzz.database import FailureState, HypofuzzDatabase, test_keys_key
 
 
 @dataclass(frozen=True)
@@ -345,3 +346,32 @@ def collect(code: str) -> CollectionResult:
 
 def collect_names(code: str) -> set[str]:
     return {fp.test_fn.__name__ for fp in collect(code).fuzz_targets}
+
+
+
+def assert_no_failures(db, key):
+    fatal_failure = db.fetch_fatal_failure(key)
+    assert not fatal_failure, fatal_failure
+
+    for state in [FailureState.SHRUNK, FailureState.UNSHRUNK, FailureState.FIXED]:
+        failures = list(db.fetch_failures(key, state=state))
+        assert not failures, [
+            db.fetch_failure_observation(key, choices, state=state)
+            for choices in failures
+        ]
+
+
+def fuzz_with_no_error(tmp_path, code):
+    test_path, db_path = setup_test_code(tmp_path, code)
+    db = HypofuzzDatabase(DirectoryBasedExampleDatabase(db_path))
+
+    with fuzz(test_path):
+        key = wait_for_test_key(db)
+        start = time.time()
+        wait_for(
+            lambda: len(list(db.fetch_observations(key))) > 5
+            or time.time() - start > 2,
+            interval=0.1,
+        )
+
+    assert_no_failures(db, key)

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,16 +1,17 @@
 import inspect
 import subprocess
 
-from common import collect_names, fuzz, setup_test_code, wait_for, wait_for_test_key
+from common import (
+    assert_no_failures,
+    collect_names,
+    fuzz,
+    setup_test_code,
+    wait_for,
+    wait_for_test_key,
+)
 from hypothesis.database import DirectoryBasedExampleDatabase
 
-from hypofuzz.database import FailureState, HypofuzzDatabase, test_keys_key
-
-
-def assert_no_failures(db, key):
-    assert not list(db.fetch_failures(key, state=FailureState.SHRUNK))
-    assert not list(db.fetch_failures(key, state=FailureState.UNSHRUNK))
-    assert not list(db.fetch_failures(key, state=FailureState.FIXED))
+from hypofuzz.database import HypofuzzDatabase, test_keys_key
 
 
 def _assert_fixtures(test_dir, db_dir):

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -10,12 +10,19 @@ from common import fuzz_with_no_error
         """
     @given(st.integers())
     def test_trivial(n):
-        pass
+        assert isinstance(n, int)
     """,
         """
     @given(st.floats(allow_infinity=False, allow_nan=False) | st.integers())
     def test_targeting(v):
         target(v)
+    """,
+        """
+    class TestClassBased:
+        @given(st.integers())
+        def test_a(self, n):
+            assert isinstance(self, TestClassBased)
+            assert isinstance(n, int)
     """,
     ],
 )

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -1,34 +1,7 @@
-import time
-
 import pytest
-from common import fuzz, setup_test_code, wait_for, wait_for_test_key
-from hypothesis.database import DirectoryBasedExampleDatabase
-
-from hypofuzz.database import FailureState, HypofuzzDatabase
+from common import fuzz_with_no_error
 
 # high-level tests that fuzzing something does not produce an error
-
-
-def fuzz_with_no_error(tmp_path, code):
-    test_path, db_path = setup_test_code(tmp_path, code)
-    db = HypofuzzDatabase(DirectoryBasedExampleDatabase(db_path))
-
-    with fuzz(test_path):
-        key = wait_for_test_key(db)
-        start = time.time()
-        wait_for(
-            lambda: len(list(db.fetch_observations(key))) > 5
-            or time.time() - start > 2,
-            interval=0.1,
-        )
-
-    assert not db.fetch_fatal_failure(key)
-    for state in [FailureState.FIXED, FailureState.SHRUNK, FailureState.UNSHRUNK]:
-        failures = list(db.fetch_failures(key, state=state))
-        assert not failures, [
-            db.fetch_failure_observation(key, choices, state=state)
-            for choices in failures
-        ]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_unittest.py
+++ b/tests/test_unittest.py
@@ -1,0 +1,41 @@
+import pytest
+from common import fuzz_with_no_error
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        """
+    class Test(TestCase):
+        @given(st.integers())
+        def test_trivial(self, n):
+            assert isinstance(self, Test)
+            assert isinstance(n, int)
+    """,
+        """
+    class Test(TestCase):
+        def setUp(self):
+            self.a = 1
+
+        @given(st.integers())
+        def test_requires_setup(self, n):
+            assert isinstance(self, Test)
+            assert isinstance(n, int)
+            assert self.a == 1
+    """,
+        """
+    class Test(TestCase):
+        @classmethod
+        def setUpClass(cls):
+            cls.a = 1
+
+        @given(st.integers())
+        def test_requires_setup_class(self, n):
+            assert isinstance(self, Test)
+            assert isinstance(n, int)
+            assert self.a == 1
+    """,
+    ],
+)
+def test_fuzz_with_no_error(tmp_path, code):
+    fuzz_with_no_error(tmp_path, code)


### PR DESCRIPTION
Turns out this wasn't too hard to support, at least for simple usages.

docs update coming soon; preview:

```

Pytest and Unittest compatibility
---------------------------------

HypoFuzz is compatible with almost all features of Pytest and Unittest. The features which are not are listed below. If any of these features are important to you, please `get in touch <mailto:sales@hypofuzz.com?subject=Test%20runner%20feature%20support>`__! They are not yet implemented in HypoFuzz due to low perceived use.

* Pytest's :ref:`xunit-style setup methods <pytest:xunitsetup>` setup and teardown methods. Like Pytest, we recommend using fixtures instead.
  * ``setup_module``, ``teardown_module``
  * ``setup_class``, ``teardown_class``
  * ``setup_method``, ``teardown_method``
  * ``setup_function``, ``teardown_function``
* Any unittest feature which is not supported by Pytest. Currently, this is just ``subTest`` and the ``load_tests`` protocol.
```