### PR TITLE
Allow `HypofuzzProvider` to be used without a database

### DIFF
--- a/src/hypofuzz/__init__.py
+++ b/src/hypofuzz/__init__.py
@@ -1,4 +1,6 @@
 """Adaptive fuzzing for property-based tests using Hypothesis."""
 
+from hypofuzz.detection import in_hypofuzz_run
+
 __version__ = "25.07.01"
-__all__: list = []
+__all__: list[str] = ["in_hypofuzz_run"]

--- a/src/hypofuzz/docs/manual/collection.rst
+++ b/src/hypofuzz/docs/manual/collection.rst
@@ -47,7 +47,7 @@ If you would like to skip a test under HypoFuzz while keeping it part of your no
     from hypofuzz.detection import in_hypofuzz_run
 
 
-    @pytest.mark.skipif(in_hypofuzz_run)
+    @pytest.mark.skipif(in_hypofuzz_run())
     @given(st.integers())
     def test_will_not_be_fuzzed(n):
         pass

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -47,7 +47,6 @@ def test_database_state():
     process._execute_once(process.new_conjecture_data(choices=[2]))
     # for coverage stability
     process._execute_once(process.new_conjecture_data())
-    process.provider.db._db._join()
 
     key = process.database_key
 
@@ -81,7 +80,6 @@ def test_database_state():
     process._execute_once(process.new_conjecture_data(choices=[1]))
     # for stability
     process._execute_once(process.new_conjecture_data())
-    process.provider.db._db._join()
 
     # the key for the deleted observation sticks around in the database, it's
     # just an empty mapping.

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -264,3 +264,22 @@ def test_invalid_data_does_not_add_coverage():
         process._execute_once(process.new_conjecture_data(choices=choices))
         assert not process.provider.corpus.behavior_counts
         assert not process.provider.corpus.fingerprints
+
+
+def test_explicit_backend_can_be_used_without_database():
+    # under `hypothesis fuzz`, the provider always has access to a database, because
+    # we skip tests with database=None during collection.
+    #
+    # But under backend="hypofuzz", we allow database=None.
+
+    called = False
+
+    @given(st.integers())
+    @settings(database=None, backend="hypofuzz")
+    def f(n):
+        nonlocal called
+        called = True
+
+    assert not called
+    f()
+    assert called


### PR DESCRIPTION
For `@settings(database=None, backend="hypofuzz")`, and incidentally nice for tests.