### PR TITLE
Save reports on worker switch + Tyche improvements

### DIFF
--- a/deps/check.txt
+++ b/deps/check.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --annotation-style=line --output-file=deps/check.txt deps/check.in
 #
-anyio==4.9.0              # via starlette
+anyio==4.10.0             # via starlette
 attrs==25.3.0             # via hypothesis, outcome, trio
 black==25.1.0             # via shed
 click==8.1.8              # via black
@@ -16,12 +16,12 @@ h2==4.2.0                 # via hypercorn
 hpack==4.1.0              # via h2
 hypercorn==0.17.3         # via -r deps/check.in
 hyperframe==6.1.0         # via h2
-hypothesis==6.136.1       # via -r deps/check.in
+hypothesis==6.136.9       # via -r deps/check.in
 idna==3.10                # via anyio, trio
 iniconfig==2.1.0          # via pytest
 libcst==1.8.2             # via shed
 mccabe==0.7.0             # via flake8
-mypy==1.17.0              # via -r deps/check.in
+mypy==1.17.1              # via -r deps/check.in
 mypy-extensions==1.1.0    # via black, mypy
 outcome==1.3.0.post0      # via trio
 packaging==25.0           # via black, pytest
@@ -37,7 +37,7 @@ pygments==2.19.2          # via pytest
 pytest==8.4.1             # via -r deps/check.in
 pyupgrade==3.20.0         # via shed
 pyyaml==6.0.2             # via libcst
-ruff==0.12.4              # via -r deps/check.in, shed
+ruff==0.12.7              # via -r deps/check.in, shed
 shed==2025.6.1            # via -r deps/check.in
 sniffio==1.3.1            # via anyio, trio
 sortedcontainers==2.4.0   # via hypothesis, sortedcontainers-stubs, trio

--- a/deps/docs.txt
+++ b/deps/docs.txt
@@ -6,15 +6,15 @@
 #
 accessible-pygments==0.0.5  # via furo
 alabaster==0.7.16         # via sphinx
-anyio==4.9.0              # via starlette
+anyio==4.10.0             # via starlette
 attrs==25.3.0             # via hypothesis, outcome, trio
 babel==2.17.0             # via sphinx
 beautifulsoup4==4.13.4    # via furo
 black==25.1.0             # via hypofuzz (pyproject.toml), hypothesis
-certifi==2025.7.14        # via requests
+certifi==2025.8.3         # via requests
 charset-normalizer==3.4.2  # via requests
 click==8.1.8              # via black, hypothesis
-coverage==7.9.2           # via hypofuzz (pyproject.toml)
+coverage==7.10.2          # via hypofuzz (pyproject.toml)
 docutils==0.21.2          # via myst-parser, pybtex-docutils, sphinx, sphinxcontrib-bibtex
 exceptiongroup==1.3.0     # via anyio, hypercorn, hypothesis, pytest, taskgroup, trio
 furo==2025.7.19           # via -r deps/docs.in
@@ -23,7 +23,7 @@ h2==4.2.0                 # via hypercorn
 hpack==4.1.0              # via h2
 hypercorn==0.17.3         # via hypofuzz (pyproject.toml)
 hyperframe==6.1.0         # via h2
-hypothesis[cli,watchdog]==6.136.1  # via hypofuzz (pyproject.toml)
+hypothesis[cli,watchdog]==6.136.9  # via hypofuzz (pyproject.toml)
 idna==3.10                # via anyio, requests, trio
 imagesize==1.4.1          # via sphinx
 importlib-metadata==8.7.0  # via pybtex, sphinx, sphinxcontrib-bibtex
@@ -50,7 +50,7 @@ pygments==2.19.2          # via accessible-pygments, furo, pytest, rich, sphinx
 pytest==8.4.1             # via hypofuzz (pyproject.toml)
 pyyaml==6.0.2             # via libcst, myst-parser, pybtex
 requests==2.32.4          # via sphinx
-rich==14.0.0              # via hypothesis
+rich==14.1.0              # via hypothesis
 sniffio==1.3.1            # via anyio, trio
 snowballstemmer==3.0.1    # via sphinx
 sortedcontainers==2.4.0   # via hypothesis, trio
@@ -68,7 +68,7 @@ starlette==0.47.2         # via hypofuzz (pyproject.toml)
 taskgroup==0.2.2          # via hypercorn
 tomli==2.2.1              # via black, hypercorn, pytest, sphinx
 trio==0.30.0              # via hypofuzz (pyproject.toml)
-typing-extensions==4.14.1  # via anyio, beautifulsoup4, black, exceptiongroup, hypercorn, libcst, rich, starlette, taskgroup
+typing-extensions==4.14.1  # via anyio, beautifulsoup4, black, exceptiongroup, hypercorn, libcst, starlette, taskgroup
 urllib3==2.5.0            # via requests
 watchdog==6.0.0           # via hypothesis
 wsproto==1.2.0            # via hypercorn

--- a/deps/test.txt
+++ b/deps/test.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile --annotation-style=line --output-file=deps/test.txt deps/test.in pyproject.toml
 #
-anyio==4.9.0              # via starlette
+anyio==4.10.0             # via starlette
 attrs==25.3.0             # via hypothesis, outcome, trio
 black==25.1.0             # via hypofuzz (pyproject.toml), hypothesis
-certifi==2025.7.14        # via requests
+certifi==2025.8.3         # via requests
 charset-normalizer==3.4.2  # via requests
 click==8.1.8              # via black, hypothesis
-coverage[toml]==7.9.2     # via hypofuzz (pyproject.toml), pytest-cov
+coverage[toml]==7.10.2    # via hypofuzz (pyproject.toml), pytest-cov
 exceptiongroup==1.3.0     # via anyio, hypercorn, hypothesis, pytest, taskgroup, trio
 execnet==2.1.1            # via pytest-xdist
 h11==0.16.0               # via hypercorn, wsproto
@@ -18,7 +18,7 @@ h2==4.2.0                 # via hypercorn
 hpack==4.1.0              # via h2
 hypercorn==0.17.3         # via hypofuzz (pyproject.toml)
 hyperframe==6.1.0         # via h2
-hypothesis[cli,watchdog]==6.136.1  # via hypofuzz (pyproject.toml)
+hypothesis[cli,watchdog]==6.136.9  # via hypofuzz (pyproject.toml)
 idna==3.10                # via anyio, requests, trio
 iniconfig==2.1.0          # via pytest
 libcst==1.8.2             # via hypofuzz (pyproject.toml)
@@ -38,14 +38,14 @@ pytest-cov==6.2.1         # via -r deps/test.in
 pytest-xdist==3.8.0       # via -r deps/test.in
 pyyaml==6.0.2             # via libcst
 requests==2.32.4          # via -r deps/test.in
-rich==14.0.0              # via hypothesis
+rich==14.1.0              # via hypothesis
 sniffio==1.3.1            # via anyio, trio
 sortedcontainers==2.4.0   # via hypothesis, trio
 starlette==0.47.2         # via hypofuzz (pyproject.toml)
 taskgroup==0.2.2          # via hypercorn
 tomli==2.2.1              # via black, coverage, hypercorn, pytest
 trio==0.30.0              # via hypofuzz (pyproject.toml)
-typing-extensions==4.14.1  # via anyio, black, exceptiongroup, hypercorn, libcst, rich, starlette, taskgroup
+typing-extensions==4.14.1  # via anyio, black, exceptiongroup, hypercorn, libcst, starlette, taskgroup
 urllib3==2.5.0            # via requests
 watchdog==6.0.0           # via hypothesis
 wsproto==1.2.0            # via hypercorn

--- a/src/hypofuzz/frontend/src/pages/Workers.tsx
+++ b/src/hypofuzz/frontend/src/pages/Workers.tsx
@@ -214,7 +214,7 @@ export function WorkersPage() {
   const navigate = useNavigate()
   const { showTooltip, hideTooltip, moveTooltip } = useTooltip()
   const [expandedWorkers, setExpandedWorkers] = useState<Set<string>>(new Set())
-  const [selectedPeriod, setSelectedPeriod] = useState<TimePeriod>(TIME_PERIODS[0]) // Default to "Latest"
+  const [selectedPeriod, setSelectedPeriod] = useState<TimePeriod>(TIME_PERIODS[0])
   const [userRange, setUserRange] = useState<[number, number] | null>(null)
 
   const workerUuids = OrderedSet(
@@ -338,8 +338,6 @@ export function WorkersPage() {
   const visibleRange = userRange ?? sliderRange
 
   useEffect(() => {
-    // reset the range when clicking on a period, even if it's the same period. This gives a
-    // nice "reset button" ux to users.
     setUserRange(null)
   }, [selectedPeriod])
 
@@ -405,7 +403,15 @@ export function WorkersPage() {
                         ? "workers__durations__button--active"
                         : ""
                     } ${!available ? "workers__durations__button--disabled" : ""}`}
-                    onClick={() => available && setSelectedPeriod(period)}
+                    onClick={() => {
+                      if (!available) {
+                        return
+                      }
+                      setSelectedPeriod(period)
+                      // reset the range when clicking on a period, even if it's the same period. This gives a
+                      // nice "reset button" ux to users.
+                      setUserRange(null)
+                    }}
                   >
                     {period.label}
                   </div>

--- a/src/hypofuzz/frontend/src/pages/Workers.tsx
+++ b/src/hypofuzz/frontend/src/pages/Workers.tsx
@@ -357,6 +357,9 @@ export function WorkersPage() {
       width = ((segment.end - segment.start) / visibleDuration) * 100
     }
 
+    // TODO we should compute a min in pixels, not percentage.
+    width = Math.max(width, 0.1)
+
     return {
       left: `${left}%`,
       width: `${width}%`,

--- a/src/hypofuzz/frontend/src/pages/Workers.tsx
+++ b/src/hypofuzz/frontend/src/pages/Workers.tsx
@@ -145,7 +145,7 @@ const WorkerBar = ({
   return (
     <div
       key={worker.uuid}
-      className={`workers__worker ${expandedWorkers.has(worker.uuid) ? "workers__worker--expanded" : ""}`}
+      className={`workers__worker${expandedWorkers.has(worker.uuid) ? " workers__worker--expanded" : ""}`}
       onClick={() => onWorkerClick(worker.uuid)}
       // these extra onMouseLeave calls shouldn't be necessary, but I've had trouble
       // with the workers__timeline__segment mouse leave handler not firing consistently

--- a/src/hypofuzz/frontend/src/styles/styles.scss
+++ b/src/hypofuzz/frontend/src/styles/styles.scss
@@ -985,7 +985,8 @@ pre code.hljs {
             color: #374151;
             overflow: hidden;
 
-            &__component {
+            // left half of the pill
+            &__name {
                 display: flex;
                 align-items: center;
                 background: rgba(108, 117, 125, 0.12);
@@ -996,7 +997,8 @@ pre code.hljs {
                 font-weight: 500;
             }
 
-            &__name {
+            // right half of the pill
+            &__value-name {
                 display: flex;
                 align-items: center;
                 background: white;

--- a/src/hypofuzz/frontend/src/styles/styles.scss
+++ b/src/hypofuzz/frontend/src/styles/styles.scss
@@ -1402,8 +1402,8 @@ pre code.hljs {
 
         padding-top: 2px;
         padding-bottom: 2px;
-        padding-left: 8px;
-        padding-right: 8px;
+        padding-left: 10px;
+        padding-right: 10px;
 
         border-radius: 4px;
 

--- a/src/hypofuzz/frontend/src/styles/styles.scss
+++ b/src/hypofuzz/frontend/src/styles/styles.scss
@@ -1026,21 +1026,24 @@ pre code.hljs {
     &__nominal {
         &__chart {
             max-width: $max-nominal-width;
-            margin-left: 1.75rem;
-            margin-bottom: 0.75rem;
-
-            @media (max-width: $mobile-breakpoint) {
-                margin-left: 0;
-            }
         }
 
         &__feature {
-            font-family: monospace;
-            font-size: 1rem;
-            font-weight: 600;
             margin-bottom: 0.5rem;
             padding: 10px 0;
-            line-height: 1.3;
+
+            &__icon {
+                color: #666;
+                margin-right: 5px;
+                font-size: 0.9em;
+            }
+
+            &__text {
+                font-family: monospace;
+                font-size: 1rem;
+                font-weight: 600;
+                line-height: 1.3;
+            }
         }
     }
 

--- a/src/hypofuzz/frontend/src/tyche/Features.tsx
+++ b/src/hypofuzz/frontend/src/tyche/Features.tsx
@@ -1,24 +1,48 @@
-import { NominalChart } from "src/tyche/NominalChart"
+import { ObservationCategory } from "src/tyche/FilterContext"
+import { NominalChart, SystemFeature, UserFeature } from "src/tyche/NominalChart"
 import { TycheSection } from "src/tyche/TycheSection"
 import { Observation } from "src/types/dashboard"
 
+// use a private name to avoid collisions with user features.
+const STABILITY_FEATURE_KEY = "__hypofuzz_stability"
+
 export function Features({
   observations,
+  observationCategory,
 }: {
   observations: { raw: Observation[]; filtered: Observation[] }
+  observationCategory: ObservationCategory
 }) {
-  const features = new Set<string>()
+  const featureNames = new Set<string>()
 
   observations.raw.forEach(obs => {
     for (const key of obs.features.keys()) {
       if (key.startsWith("Retried draw from")) {
         continue
       }
-      features.add(key)
+      featureNames.add(key)
     }
   })
 
-  if (features.size === 0) {
+  const features = Array.from(featureNames).map(
+    feature => new UserFeature(feature, feature),
+  )
+  // we currently only add covering observations if they are stable, and don't re-check for
+  // stability after. Skip here to avoid showing a boring graph full of "stable" for the
+  // covering observation view.
+  //
+  // We should also enable this for covering if/when we have more interesting data to show.
+  if (observationCategory == "rolling") {
+    features.push(
+      new SystemFeature(
+        STABILITY_FEATURE_KEY,
+        "Stability",
+        observation => observation.stability ?? "unknown",
+      ),
+    )
+  }
+
+  if (features.length === 0) {
     return null
   }
 
@@ -26,7 +50,7 @@ export function Features({
     <TycheSection title="Features">
       {/* sort for stable display order */}
       {Array.from(features)
-        .sort()
+        .sortKey(feature => feature.name)
         .map(feature => (
           <NominalChart feature={feature} observations={observations} />
         ))}

--- a/src/hypofuzz/frontend/src/tyche/FilterContext.tsx
+++ b/src/hypofuzz/frontend/src/tyche/FilterContext.tsx
@@ -16,9 +16,11 @@ export class Filter {
   }
 }
 
+type Filters = Map<string, Filter[]>
+
 interface FilterContextType {
-  filters: Map<string, Filter[]>
-  setFilters: (filters: Map<string, Filter[]>) => void
+  filters: Filters
+  setFilters: (filters: Filters) => void
   removeFilter: (component: string, name: string) => void
   observationCategory: ObservationCategory
   setObservationCategory: (observationCategory: ObservationCategory) => void
@@ -28,7 +30,7 @@ const FilterContext = createContext<FilterContextType | undefined>(undefined)
 
 export function FilterProvider({ children }: { children: ReactNode }) {
   const [filtersByObsType, setFiltersByCategory] = useState<
-    Map<ObservationCategory, Map<string, Filter[]>>
+    Map<ObservationCategory, Filters>
   >(
     new Map([
       ["covering", new Map()],
@@ -40,7 +42,7 @@ export function FilterProvider({ children }: { children: ReactNode }) {
 
   const filters =
     filtersByObsType.get(observationCategory) || new Map<string, Filter[]>()
-  const setFilters = (newFilters: Map<string, Filter[]>) => {
+  const setFilters = (newFilters: Filters) => {
     setFiltersByCategory(prev => {
       const newMap = new Map(prev)
       newMap.set(observationCategory, newFilters)

--- a/src/hypofuzz/frontend/src/tyche/FilterContext.tsx
+++ b/src/hypofuzz/frontend/src/tyche/FilterContext.tsx
@@ -7,9 +7,12 @@ export class Filter {
   createdAt: number
 
   constructor(
+    // display value for the left half (key) of a "current filters" tag
     public readonly name: string,
+    // display value for the right half (value) of a "current filters" tag
+    public readonly valueName: string,
     public readonly predicate: (observation: Observation) => boolean,
-    public readonly component: string,
+    public readonly key: string,
     public readonly extraData?: any,
   ) {
     this.createdAt = Date.now()
@@ -21,7 +24,7 @@ type Filters = Map<string, Filter[]>
 interface FilterContextType {
   filters: Filters
   setFilters: (filters: Filters) => void
-  removeFilter: (component: string, name: string) => void
+  removeFilter: (key: string) => void
   observationCategory: ObservationCategory
   setObservationCategory: (observationCategory: ObservationCategory) => void
 }
@@ -29,7 +32,7 @@ interface FilterContextType {
 const FilterContext = createContext<FilterContextType | undefined>(undefined)
 
 export function FilterProvider({ children }: { children: ReactNode }) {
-  const [filtersByObsType, setFiltersByCategory] = useState<
+  const [filtersByObsType, setFiltersByKey] = useState<
     Map<ObservationCategory, Filters>
   >(
     new Map([
@@ -43,22 +46,22 @@ export function FilterProvider({ children }: { children: ReactNode }) {
   const filters =
     filtersByObsType.get(observationCategory) || new Map<string, Filter[]>()
   const setFilters = (newFilters: Filters) => {
-    setFiltersByCategory(prev => {
+    setFiltersByKey(prev => {
       const newMap = new Map(prev)
       newMap.set(observationCategory, newFilters)
       return newMap
     })
   }
 
-  const removeFilter = (component: string, name: string) => {
+  const removeFilter = (key: string) => {
     const newFilters = new Map(filters)
-    const componentFilters = newFilters.get(component) || []
-    const filteredFilters = componentFilters.filter(f => f.name !== name)
+    const keyFilters = newFilters.get(key) || []
+    const filteredFilters = keyFilters.filter(f => f.key !== key)
 
     if (filteredFilters.length === 0) {
-      newFilters.delete(component)
+      newFilters.delete(key)
     } else {
-      newFilters.set(component, filteredFilters)
+      newFilters.set(key, filteredFilters)
     }
 
     setFilters(newFilters)

--- a/src/hypofuzz/frontend/src/tyche/Filters.tsx
+++ b/src/hypofuzz/frontend/src/tyche/Filters.tsx
@@ -17,20 +17,17 @@ export function Filters() {
     <div className="tyche__filters">
       <div className="tyche__filters__title">Current Filters</div>
       {allFilters.map(filter => (
-        <div
-          key={`${filter.component}-${filter.name}`}
-          className="tyche__filters__filter"
-        >
-          <div className="tyche__filters__filter__component">
+        <div key={filter.key} className="tyche__filters__filter">
+          <div className="tyche__filters__filter__name">
             <div
               className="tyche__filters__filter__remove"
-              onClick={() => removeFilter(filter.component, filter.name)}
+              onClick={() => removeFilter(filter.key)}
             >
               <FontAwesomeIcon icon={faXmark} />
             </div>
-            {filter.component}
+            {filter.name}
           </div>
-          <div className="tyche__filters__filter__name">{filter.name}</div>
+          <div className="tyche__filters__filter__value-name">{filter.valueName}</div>
         </div>
       ))}
     </div>

--- a/src/hypofuzz/frontend/src/tyche/MosaicChart.tsx
+++ b/src/hypofuzz/frontend/src/tyche/MosaicChart.tsx
@@ -164,6 +164,7 @@ export function MosaicChart({
     if (newSelection.size > 0) {
       mosaicFilters.push(
         new Filter(
+          name,
           filterName(),
           (obs: Observation) => {
             return newSelection.some(cell => {

--- a/src/hypofuzz/frontend/src/tyche/NominalChart.tsx
+++ b/src/hypofuzz/frontend/src/tyche/NominalChart.tsx
@@ -97,6 +97,10 @@ export function NominalChart({ feature, observations }: NominalChartProps) {
   }
 
   useEffect(() => {
+    if (filteredObservations.filtered.length == 0) {
+      return
+    }
+
     const distinctRawValues = Set<string>(
       filteredObservations.raw.map(obs => obs.features.get(feature)),
     )
@@ -328,6 +332,10 @@ export function NominalChart({ feature, observations }: NominalChartProps) {
     selectedValues,
     showTooltip,
   ])
+
+  if (filteredObservations.filtered.length == 0) {
+    return null
+  }
 
   return (
     <div>

--- a/src/hypofuzz/frontend/src/tyche/NominalChart.tsx
+++ b/src/hypofuzz/frontend/src/tyche/NominalChart.tsx
@@ -100,24 +100,25 @@ export function NominalChart({ feature, observations }: NominalChartProps) {
       newSelection = Set([value])
     }
 
-    let name
+    let valueName
     if (newSelection.size === 1) {
-      name = newSelection.first()!
+      valueName = newSelection.first()!
     } else {
-      name = newSelection.map(value => `${value}`).join(" or ")
+      valueName = newSelection.map(value => `${value}`).join(" or ")
     }
 
     const nominalFilters = []
     if (newSelection.size > 0) {
       nominalFilters.push(
         new Filter(
-          name,
+          feature.name,
+          valueName,
           (obs: Observation) => {
             return newSelection.some(value => {
               return value === feature.getValue(obs)
             })
           },
-          feature.key,
+          `nominal-${feature.key}`,
           {
             selectedValues: newSelection,
           },

--- a/src/hypofuzz/frontend/src/tyche/NominalChart.tsx
+++ b/src/hypofuzz/frontend/src/tyche/NominalChart.tsx
@@ -1,3 +1,5 @@
+import { faGear } from "@fortawesome/free-solid-svg-icons"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { axisBottom as d3_axisBottom, axisLeft as d3_axisLeft } from "d3-axis"
 import {
   scaleBand as d3_scaleBand,
@@ -23,13 +25,45 @@ const d3 = {
   axisLeft: d3_axisLeft,
 }
 
+export abstract class Feature {
+  abstract isSystem: boolean
+
+  constructor(
+    public key: string,
+    public name: string,
+  ) {}
+
+  getValue(observation: Observation): any {
+    return observation.features.get(this.name)
+  }
+}
+
+export class UserFeature extends Feature {
+  isSystem = false
+}
+
+export class SystemFeature extends Feature {
+  isSystem = true
+
+  constructor(
+    public override key: string,
+    public override name: string,
+    public value: (observation: Observation) => any,
+  ) {
+    super(key, name)
+  }
+
+  override getValue(observation: Observation): any {
+    return this.value(observation)
+  }
+}
+
 type NominalChartProps = {
-  feature: string
+  feature: Feature
   observations: { raw: Observation[]; filtered: Observation[] }
 }
 
 const HORIZONTAL_BAR_FEATURE_CUTOFF = 5
-
 const SELECTION_STROKE_WIDTH = 2.5
 
 export function NominalChart({ feature, observations }: NominalChartProps) {
@@ -39,7 +73,7 @@ export function NominalChart({ feature, observations }: NominalChartProps) {
   const { showTooltip, hideTooltip, moveTooltip } = useTooltip()
 
   function getSelectedValues() {
-    const nominalFilters = filters.get(feature) || []
+    const nominalFilters = filters.get(feature.key) || []
     if (nominalFilters.length === 0) {
       return Set<string>()
     }
@@ -80,10 +114,10 @@ export function NominalChart({ feature, observations }: NominalChartProps) {
           name,
           (obs: Observation) => {
             return newSelection.some(value => {
-              return obs.features.get(feature) === value
+              return value === feature.getValue(obs)
             })
           },
-          feature,
+          feature.key,
           {
             selectedValues: newSelection,
           },
@@ -92,7 +126,7 @@ export function NominalChart({ feature, observations }: NominalChartProps) {
     }
 
     const newFilters = new Map(filters)
-    newFilters.set(feature, nominalFilters)
+    newFilters.set(feature.key, nominalFilters)
     setFilters(newFilters)
   }
 
@@ -102,13 +136,13 @@ export function NominalChart({ feature, observations }: NominalChartProps) {
     }
 
     const distinctRawValues = Set<string>(
-      filteredObservations.raw.map(obs => obs.features.get(feature)),
+      filteredObservations.raw.map(obs => feature.getValue(obs)),
     )
     // value: count
     let data = new Map<string, number>()
 
     for (const observation of filteredObservations.filtered) {
-      const value = observation.features.get(feature)
+      const value = feature.getValue(observation)
       data.set(value, (data.get(value) || 0) + 1)
     }
     const total = sum(Array.from(data.values()))
@@ -135,7 +169,7 @@ export function NominalChart({ feature, observations }: NominalChartProps) {
     const showTooltipHandler = function (event: MouseEvent, d: [string, number]) {
       const [label, count] = d
       showTooltip(
-        `${feature}<br>${label}: ${count}`,
+        `${feature.name}<br>${label}: ${count}`,
         event.clientX,
         event.clientY,
         "tyche-nominal",
@@ -148,7 +182,7 @@ export function NominalChart({ feature, observations }: NominalChartProps) {
     // use the number of distinct values in the unfiltered observations, so we
     // don't change up the display type on the user when they're drilling down.
     if (distinctRawValues.size < HORIZONTAL_BAR_FEATURE_CUTOFF) {
-      const margin = { top: 0, right: 15, bottom: 20, left: 15 }
+      const margin = { top: 0, right: 15, bottom: 20, left: 10 }
       const innerWidth = width - margin.left - margin.right
       const innerHeight = height - margin.top - margin.bottom
 
@@ -222,8 +256,8 @@ export function NominalChart({ feature, observations }: NominalChartProps) {
           .attr("dominant-baseline", "central")
           .attr("fill", "white")
           .text(value)
-          .style("font-size", "12px")
-
+          .style("font-size", "14px")
+          .style("font-weight", "bold")
         xAccumulator += barWidth
       })
 
@@ -233,13 +267,13 @@ export function NominalChart({ feature, observations }: NominalChartProps) {
 
       g.append("text")
         .attr("x", innerWidth / 2)
-        .attr("y", barHeight + 30)
+        .attr("y", barHeight + 35)
         .attr("text-anchor", "middle")
         .text("% of observations")
-        .style("font-size", "12px")
+        .style("font-size", "13px")
     } else {
       // add some margin inset for the graph proper so the axes don't get cut off
-      const margin = { top: 5, right: 5, bottom: 30, left: 30 }
+      const margin = { top: 5, right: 5, bottom: 30, left: 10 }
       const innerWidth = width - margin.left - margin.right
       const innerHeight = height - margin.top - margin.bottom
 
@@ -339,7 +373,17 @@ export function NominalChart({ feature, observations }: NominalChartProps) {
 
   return (
     <div>
-      <div className="tyche__nominal__feature">{feature}</div>
+      <div className="tyche__nominal__feature">
+        {feature.isSystem && (
+          <span className="tooltip">
+            <FontAwesomeIcon icon={faGear} className="tyche__nominal__feature__icon" />
+            <span className="tooltip__text">
+              This feature is generated automatically for all tests
+            </span>
+          </span>
+        )}
+        <span className="tyche__nominal__feature__text">{feature.name}</span>
+      </div>
       <div ref={parentRef} className="tyche__nominal__chart">
         <svg ref={svgRef} style={{ width: "100%" }}></svg>
       </div>

--- a/src/hypofuzz/frontend/src/tyche/NominalChart.tsx
+++ b/src/hypofuzz/frontend/src/tyche/NominalChart.tsx
@@ -198,7 +198,8 @@ export function NominalChart({ feature, observations }: NominalChartProps) {
       } else {
         colorScale = d3
           .scaleOrdinal<string>()
-          .domain(Array.from(data.keys()))
+          // use raw values so the coloring doesn't change as we drill down
+          .domain(distinctRawValues)
           .range([
             TYCHE_COLOR.PRIMARY,
             TYCHE_COLOR.ACCENT,

--- a/src/hypofuzz/frontend/src/tyche/Tyche.tsx
+++ b/src/hypofuzz/frontend/src/tyche/Tyche.tsx
@@ -76,7 +76,10 @@ function TycheInner({ test }: { test: Test }) {
       {observations.raw.length > 0 ? (
         <>
           <Samples observations={observations} />
-          <Features observations={observations} />
+          <Features
+            observations={observations}
+            observationCategory={observationCategory}
+          />
           <Representation
             observations={observations}
             observationCategory={observationCategory}

--- a/src/hypofuzz/hypofuzz.py
+++ b/src/hypofuzz/hypofuzz.py
@@ -66,7 +66,9 @@ try:
         with_observation_callback as with_observability_callback,
     )
 except ImportError:
-    from hypothesis.internal.observability import with_observability_callback
+    from hypothesis.internal.observability import (
+        with_observability_callback,  # type: ignore
+    )
 
 # 1 hour
 SHRINK_TIMEOUT = 60 * 60

--- a/src/hypofuzz/hypofuzz.py
+++ b/src/hypofuzz/hypofuzz.py
@@ -66,8 +66,8 @@ try:
         with_observation_callback as with_observability_callback,
     )
 except ImportError:
-    from hypothesis.internal.observability import (
-        with_observability_callback,  # type: ignore
+    from hypothesis.internal.observability import (  # type: ignore
+        with_observability_callback,
     )
 
 # 1 hour


### PR DESCRIPTION
Stability is a new tyche feature:

<img width="700" height="687" alt="image" src="https://github.com/user-attachments/assets/030d3192-cfce-432a-8a1d-75c4d61f5e5a" />


The gear icon indicates we generate this automatically, to avoid confusing the user ("why do I have a feature which doesn't correspond to any event/target/note call in my code?") 

<img width="358" height="183" alt="image" src="https://github.com/user-attachments/assets/2213b10a-b7cc-47c6-8c08-829f08e32daf" />


I do not know why there are so many "unknown" stability events here. There should be 0. Probably a bug.