### PR TITLE
Better graph hover and stability computation

### DIFF
--- a/src/hypofuzz/dashboard/test.py
+++ b/src/hypofuzz/dashboard/test.py
@@ -215,11 +215,19 @@ class Test:
         if not self.rolling_observations:
             return None
 
+        # not that we do not compute stability as
+        # count_stable / len(self.rolling_observations), because we want to avoid
+        # counting observations with unknown stability against the overall stability.
         count_stable = sum(
             observation.stability is Stability.STABLE
             for observation in self.rolling_observations
         )
-        return count_stable / len(self.rolling_observations)
+        count_unstable = sum(
+            observation.stability is Stability.UNSTABLE
+            for observation in self.rolling_observations
+        )
+
+        return count_stable / (count_stable + count_unstable)
 
     @property
     def phase(self) -> Optional[Phase]:

--- a/src/hypofuzz/frontend/src/components/graph/DataLines.tsx
+++ b/src/hypofuzz/frontend/src/components/graph/DataLines.tsx
@@ -1,6 +1,5 @@
 import { ScaleContinuousNumeric } from "d3-scale"
 import { line as d3_line } from "d3-shape"
-import { useState } from "react"
 import { navigateOnClick } from "src/utils/utils"
 
 import { GraphLine, GraphReport } from "./types"
@@ -23,45 +22,33 @@ export function DataLines({
   yValue,
   navigate,
 }: DataLinesProps) {
-  const [hoveredLineKey, setHoveredLineKey] = useState<string | null>(null)
-
   // Calculate path data using D3 with viewport scales (zoom already applied)
   const lineGenerator = d3_line<GraphReport>()
     .x(d => viewportXScale(xValue(d)))
     .y(d => viewportYScale(yValue(d)))
-
-  const lineData = lines.map((line, index) => {
-    const pathData = lineGenerator(line.reports) || ""
-
-    return {
-      pathData,
-      color: line.color,
-      url: line.url,
-      key: `line-${index}-${line.url || "no-url"}`, // Stable key for React
-    }
-  })
-
   return (
     <g style={{ pointerEvents: "auto" }}>
-      {lineData.map(line => (
-        <path
-          key={line.key}
-          d={line.pathData}
-          fill="none"
-          stroke={line.color}
-          className={`coverage-line ${hoveredLineKey === line.key ? "coverage-line__selected" : ""}`}
-          style={{
-            cursor: line.url ? "pointer" : "default",
-          }}
-          onMouseEnter={() => setHoveredLineKey(line.key)}
-          onMouseLeave={() => setHoveredLineKey(null)}
-          onClick={event => {
-            if (line.url) {
-              navigateOnClick(event as any, line.url, navigate)
-            }
-          }}
-        />
-      ))}
+      {lines.map(line => {
+        const pathData = lineGenerator(line.reports) || ""
+
+        return (
+          <path
+            key={`line-${line.url || "no-url"}`}
+            d={pathData}
+            fill="none"
+            stroke={line.color}
+            className={`coverage-line ${line.isActive ? "coverage-line__selected" : ""}`}
+            style={{
+              cursor: line.url ? "pointer" : "default",
+            }}
+            onClick={event => {
+              if (line.url) {
+                navigateOnClick(event as any, line.url, navigate)
+              }
+            }}
+          />
+        )
+      })}
     </g>
   )
 }

--- a/src/hypofuzz/frontend/src/components/graph/types.ts
+++ b/src/hypofuzz/frontend/src/components/graph/types.ts
@@ -21,7 +21,9 @@ export class GraphReport {
 }
 
 export interface GraphLine {
+  nodeid: string
   url: string | null
   reports: GraphReport[]
   color: string
+  isActive: boolean
 }

--- a/src/hypofuzz/provider.py
+++ b/src/hypofuzz/provider.py
@@ -604,7 +604,7 @@ class HypofuzzProvider(PrimitiveProvider):
                 state=FailureState.SHRUNK,
             )
 
-    def _save_obsevation(
+    def _save_observation(
         self, observation: TestCaseObservation, *, stability: Optional[Stability]
     ) -> None:
         assert self.db is not None
@@ -688,7 +688,7 @@ class HypofuzzProvider(PrimitiveProvider):
                     coverage_observation = self._state.extra_queue_data["observation"]
                     consider_corpus_coverage = True
             if "observation" in self._state.extra_queue_data["reasons"]:
-                self._save_obsevation(
+                self._save_observation(
                     # Use the observation from the original execution, not this
                     # re-execution. The re-execution is just to check for stability.
                     self._state.extra_queue_data["observation"],
@@ -784,7 +784,7 @@ class HypofuzzProvider(PrimitiveProvider):
                 # we've gone over overhead cap for observation stability, we
                 # instead save an observation without re-executing, with an
                 # unknown stability status.
-                self._save_obsevation(observation, stability=None)
+                self._save_observation(observation, stability=None)
 
         if queue_for_stability:
             self._enqueue(


### PR DESCRIPTION
Lines show as hovered within a 10px radius now, instead of only directly on hover. The implementation is more complicated than it sounds: we build a quadtree of sampled points from the lines, for efficient range checking, to avoid O(n) sqrts every iteration.