### PR TITLE
Refactor worker identity

### DIFF
--- a/src/hypofuzz/utils.py
+++ b/src/hypofuzz/utils.py
@@ -4,10 +4,13 @@ import threading
 from collections.abc import Sequence
 from enum import Enum
 from typing import Any, Callable, Generic, Optional, TypeVar
+from uuid import uuid4
 
 from hypofuzz.compat import bisect_right
 
 T = TypeVar("T")
+
+process_uuid = uuid4().hex
 
 FUZZJSON_INF = "hypofuzz-inf-a928fa52b3ea4a9a9af36ccef7c6cf93"
 FUZZJSON_NINF = "hypofuzz-ninf-a928fa52b3ea4a9a9af36ccef7c6cf93"

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -76,12 +76,11 @@ def test_database_state():
 
     # the database state should be:
     # * database_key.hypofuzz.test_keys                 (1 element)
-    # * database_key.hypofuzz.worker_identity           (1 element)
     # * database_key.hypofuzz.observations              (1 element)
     # * database_key.hypofuzz.corpus                    (1 element)
     # * database_key.hypofuzz.corpus.<hash>.observation (1 element)
     # * database_key.hypofuzz.reports                   (1 element)
-    assert len(db._db.data.keys()) == 6, list(db._db.data.keys())
+    assert len(db._db.data.keys()) == 5, list(db._db.data.keys())
     assert list(db.corpus.fetch(key)) == [(2,)]
 
     observations = list(db.corpus_observations.fetch_all(key, (2,)))
@@ -96,7 +95,6 @@ def test_database_state():
     # input.
     # The database state should be:
     # * database_key.hypofuzz.test_keys                 (1 element)
-    # * database_key.hypofuzz.worker_identity           (1 element)
     # * database_key.hypofuzz.observations              (maybe 2 elements, if > 1 second)
     # * database_key.hypofuzz.corpus                    (1 element) (a new one)
     # * database_key.hypofuzz.corpus.<hash>.observation (1 element) (a new one)
@@ -107,7 +105,7 @@ def test_database_state():
 
     # the key for the deleted observation sticks around in the database, it's
     # just an empty mapping.
-    assert len([k for k, v in db._db.data.items() if v]) == 6
+    assert len([k for k, v in db._db.data.items() if v]) == 5
     assert list(db.corpus.fetch(key)) == [(1,)]
 
     observations = list(db.corpus_observations.fetch_all(key, (1,)))

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -2,7 +2,9 @@ import multiprocessing
 from multiprocessing import Process
 
 from common import setup_test_code, wait_for
+from hypothesis.database import DirectoryBasedExampleDatabase
 
+from hypofuzz.database import HypofuzzDatabase
 from hypofuzz.hypofuzz import _start_worker
 
 test_code = """
@@ -20,24 +22,28 @@ def test_c():
 """
 
 
+def start_worker(manager, *, pytest_args, nodeids: list[str] = []) -> None:
+    shared_state = manager.dict()
+    shared_state["hub_state"] = manager.dict()
+    shared_state["hub_state"]["nodeids"] = nodeids
+    shared_state["worker_state"] = manager.dict()
+    shared_state["worker_state"]["nodeids"] = manager.dict()
+    shared_state["worker_state"]["valid_nodeids"] = manager.list()
+    shared_state["worker_state"]["current_lifetime"] = 0.0
+    shared_state["worker_state"]["expected_lifetime"] = 0.0
+    process = Process(
+        target=_start_worker,
+        kwargs={"pytest_args": pytest_args, "shared_state": shared_state},
+    )
+    process.start()
+    return (process, shared_state)
+
+
 def test_workers(tmp_path):
     test_dir, _db_dir = setup_test_code(tmp_path, test_code)
 
     with multiprocessing.Manager() as manager:
-        shared_state = manager.dict()
-        shared_state["hub_state"] = manager.dict()
-        shared_state["hub_state"]["nodeids"] = []
-        shared_state["worker_state"] = manager.dict()
-        shared_state["worker_state"]["nodeids"] = manager.dict()
-        shared_state["worker_state"]["valid_nodeids"] = manager.list()
-        shared_state["worker_state"]["current_lifetime"] = 0.0
-        shared_state["worker_state"]["expected_lifetime"] = 0.0
-        process = Process(
-            target=_start_worker,
-            kwargs={"pytest_args": [str(test_dir)], "shared_state": shared_state},
-        )
-        process.start()
-
+        process, shared_state = start_worker(manager, pytest_args=[str(test_dir)])
         assert shared_state["hub_state"]["nodeids"] == []
 
         shared_state["hub_state"]["nodeids"] = ["test_a.py::test_a"]
@@ -47,6 +53,20 @@ def test_workers(tmp_path):
             interval=0.01,
         )
         assert shared_state["worker_state"]["current_lifetime"] > 0.0
+
+        process.kill()
+        process.join()
+
+
+def test_worker_writes_worker_identity(tmp_path):
+    test_dir, db_dir = setup_test_code(tmp_path, test_code)
+    db = HypofuzzDatabase(DirectoryBasedExampleDatabase(db_dir))
+    with multiprocessing.Manager() as manager:
+        process, _shared_state = start_worker(manager, pytest_args=[str(test_dir)])
+
+        wait_for(lambda: len(list(db.worker_uuids.fetch())) > 0, interval=0.01)
+        uuid = list(db.worker_uuids.fetch())[0]
+        wait_for(lambda: db.worker_identities.fetch(uuid) is not None, interval=0.01)
 
         process.kill()
         process.join()


### PR DESCRIPTION
We were associating `WorkerIdentity` with the database key of a `FuzzTarget` before. But a worker might have many targets. This pulls out the database entry to a top-level key. 

One effect of this is `worker_identity(in_directory=...)` for the git hash search is no longer unambiguous in which directory we should choose, since a worker has multiple collected targets. Currently we pick an arbitrary one, but we might do something smarted in the future (smallest parent shared by all targets? careful of outliers...). This only causes problems with submodules/etc, so I'm not too worried.