### PR TITLE
Remove common nodeid prefix in display, fuzzjson performance improvements

### DIFF
--- a/src/hypofuzz/dashboard/api.py
+++ b/src/hypofuzz/dashboard/api.py
@@ -17,13 +17,12 @@ from hypofuzz.dashboard.patching import (
     failing_patch,
 )
 from hypofuzz.database import HypofuzzEncoder
-from hypofuzz.utils import convert_to_fuzzjson
 
 
 class HypofuzzJSONResponse(JSONResponse):
     def render(self, content: Any) -> bytes:
         data = json.dumps(
-            convert_to_fuzzjson(content),
+            content,
             ensure_ascii=False,
             separators=(",", ":"),
             cls=HypofuzzEncoder,

--- a/src/hypofuzz/dashboard/models.py
+++ b/src/hypofuzz/dashboard/models.py
@@ -144,7 +144,7 @@ class SetStatusEvent(DashboardEvent):
 @dataclass
 class TestLoadFinishedEvent(DashboardEvent):
     type = DashboardEventType.TEST_LOAD_FINISHED
-    nodeid: str
+    nodeids: list[str]
 
 
 @dataclass

--- a/src/hypofuzz/dashboard/websocket.py
+++ b/src/hypofuzz/dashboard/websocket.py
@@ -21,7 +21,6 @@ from hypofuzz.dashboard.models import (
 )
 from hypofuzz.dashboard.test import Test
 from hypofuzz.database import HypofuzzEncoder, ReportWithDiff
-from hypofuzz.utils import convert_to_fuzzjson
 
 websockets: set["HypofuzzWebsocket"] = set()
 
@@ -73,9 +72,7 @@ class HypofuzzWebsocket(abc.ABC):
         await self.websocket.receive_json()
 
     async def send_json(self, data: Any) -> None:
-        await self.websocket.send_text(
-            json.dumps(convert_to_fuzzjson(data), cls=HypofuzzEncoder)
-        )
+        await self.websocket.send_text(json.dumps(data, cls=HypofuzzEncoder))
 
     async def send_event(self, event: DashboardEventT) -> None:
         data = {

--- a/src/hypofuzz/dashboard/websocket.py
+++ b/src/hypofuzz/dashboard/websocket.py
@@ -174,9 +174,10 @@ class TestWebsocket(HypofuzzWebsocket):
         )
         await self.send_event(test_data)
 
-        # then its reports. Note we don't currently downsample with _sample_reports
-        # on individual test pages, unlike the overview page.
-        for worker_uuid, reports in test.reports_by_worker.items():
+        # then its reports. Note we still downsample reports_by_worker, but with
+        # a higher limit than the overview page.
+        reports_by_worker = _sample_reports(test.reports_by_worker, soft_limit=5_000)
+        for worker_uuid, reports in reports_by_worker.items():
             report_event = AddReportsEvent(
                 nodeid=test.nodeid,
                 worker_uuid=worker_uuid,

--- a/src/hypofuzz/dashboard/websocket.py
+++ b/src/hypofuzz/dashboard/websocket.py
@@ -138,7 +138,7 @@ class OverviewWebsocket(HypofuzzWebsocket):
                 )
                 await self.send_event(report_event)
 
-            await broadcast_event(TestLoadFinishedEvent(nodeid=test.nodeid))
+            await broadcast_event(TestLoadFinishedEvent(nodeids=[test.nodeid]))
 
     async def on_event(self, event: DashboardEventT) -> None:
         # skip observations to the websocket page
@@ -198,7 +198,7 @@ class TestWebsocket(HypofuzzWebsocket):
                 )
             )
 
-        await broadcast_event(TestLoadFinishedEvent(nodeid=self.nodeid))
+        await broadcast_event(TestLoadFinishedEvent(nodeids=[self.nodeid]))
 
     async def on_event(self, event: DashboardEventT) -> None:
         # we only send these events for test websockets
@@ -211,10 +211,14 @@ class TestWebsocket(HypofuzzWebsocket):
         ]:
             return
 
-        assert hasattr(event, "nodeid")
-        # only broadcast event for this nodeid
-        if event.nodeid != self.nodeid:
-            return
+        # only broadcast events related to this nodeid
+        if isinstance(event, TestLoadFinishedEvent):
+            if self.nodeid not in event.nodeids:
+                return
+        else:
+            assert hasattr(event, "nodeid")
+            if event.nodeid != self.nodeid:
+                return
 
         await self.send_event(event)
 

--- a/src/hypofuzz/database/models.py
+++ b/src/hypofuzz/database/models.py
@@ -15,6 +15,8 @@ from hypothesis.internal.observability import (
     TestCaseObservation,
 )
 
+from hypofuzz.utils import convert_to_fuzzjson
+
 
 @dataclass(frozen=True)
 class WorkerIdentity:
@@ -114,9 +116,9 @@ class Observation:
             status=ObservationStatus(observation.status),
             status_reason=observation.status_reason,
             representation=observation.representation,
-            arguments=observation.arguments,
+            arguments=convert_to_fuzzjson(observation.arguments),
             how_generated=observation.how_generated,
-            features=observation.features,
+            features=convert_to_fuzzjson(observation.features),
             timing=observation.timing,
             metadata=ObservationMetadata.from_hypothesis(observation.metadata),
             property=observation.property,

--- a/src/hypofuzz/frontend/src/components/TestTable.tsx
+++ b/src/hypofuzz/frontend/src/components/TestTable.tsx
@@ -15,6 +15,7 @@ import { statusStrings, TestStatusPill } from "src/components/TestStatusPill"
 import { Tooltip } from "src/components/Tooltip"
 import { Test } from "src/types/test"
 import { getTestStats, inputsPerSecond } from "src/utils/testStats"
+import { commonPrefix } from "src/utils/utils"
 
 function Icon({ icon, tooltip }: { icon: IconDefinition; tooltip: string }) {
   return (
@@ -57,6 +58,7 @@ export function TestTable({ tests, onFilterChange }: Props) {
     })
     .map(([nodeid, test]) => test)
 
+  const nodeidPrefix = commonPrefix(sortedTests.map(t => t.nodeid))
   const iconInputs = <Icon icon={faHashtag} tooltip="Number of inputs" />
   const iconBehaviors = (
     <Icon
@@ -131,6 +133,7 @@ export function TestTable({ tests, onFilterChange }: Props) {
 
   const row = (test: Test): React.ReactNode[] => {
     const stats = getTestStats(test)
+    const nodeid = test.nodeid.slice(nodeidPrefix.length)
 
     return [
       <Link
@@ -138,7 +141,7 @@ export function TestTable({ tests, onFilterChange }: Props) {
         className="test__link"
         style={{ wordBreak: "break-all" }}
       >
-        {test.nodeid}
+        {nodeid}
       </Link>,
       <div style={{ textAlign: "center" }}>
         <TestStatusPill status={test.status} />
@@ -169,6 +172,7 @@ export function TestTable({ tests, onFilterChange }: Props) {
 
   function mobileRow(test: Test) {
     const stats = getTestStats(test)
+    const nodeid = test.nodeid.slice(nodeidPrefix.length)
 
     return (
       <div className="table__mobile-row">
@@ -178,7 +182,7 @@ export function TestTable({ tests, onFilterChange }: Props) {
             className="test__link"
             style={{ wordBreak: "break-all" }}
           >
-            {test.nodeid}
+            {nodeid}
           </Link>
           <TestStatusPill status={test.status} />
         </div>

--- a/src/hypofuzz/frontend/src/context/DataProvider.tsx
+++ b/src/hypofuzz/frontend/src/context/DataProvider.tsx
@@ -83,7 +83,7 @@ type TestsAction =
     }
   | {
       type: DashboardEventType.TEST_LOAD_FINISHED
-      nodeid: string
+      nodeids: string[]
     }
   | {
       type: DashboardEventType.SET_FATAL_FAILURE

--- a/src/hypofuzz/frontend/src/pages/CollectionStatus.tsx
+++ b/src/hypofuzz/frontend/src/pages/CollectionStatus.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react"
 import { Link } from "react-router-dom"
 import { Table } from "src/components/Table"
 import { CollectionResult, fetchCollectionStatus } from "src/utils/api"
+import { commonPrefix } from "src/utils/utils"
 
 const statusOrder = {
   not_collected: 0,
@@ -38,6 +39,8 @@ export function CollectionStatusPage() {
     result.nodeid,
   ])
 
+  const nodeidPrefix = commonPrefix(sortedResults.map(r => r.nodeid))
+
   const headers = [
     {
       content: "Test",
@@ -54,15 +57,16 @@ export function CollectionStatusPage() {
   ]
 
   const row = (item: CollectionResult): React.ReactNode[] => {
+    const nodeid = item.nodeid.slice(nodeidPrefix.length)
     const nodeidRow = (
       <div style={{ wordBreak: "break-all" }}>
         {/* don't link to a nonexistent page */}
         {item.status == "collected" ? (
           <Link to={`/tests/${encodeURIComponent(item.nodeid)}`} className="test__link">
-            {item.nodeid}
+            {nodeid}
           </Link>
         ) : (
-          item.nodeid
+          nodeid
         )}
       </div>
     )

--- a/src/hypofuzz/frontend/src/utils/fuzzjson.ts
+++ b/src/hypofuzz/frontend/src/utils/fuzzjson.ts
@@ -1,7 +1,7 @@
 // must match python's hypofuzz.utils
-const FUZZJSON_INF = "hypofuzz-inf-a928fa52b3ea4a9a9af36ccef7c6cf93"
-const FUZZJSON_NINF = "hypofuzz-ninf-a928fa52b3ea4a9a9af36ccef7c6cf93"
-const FUZZJSON_NAN = "hypofuzz-nan-a928fa52b3ea4a9a9af36ccef7c6cf93"
+const FUZZJSON_INF = "hypofuzz-inf-a928fa52b3ea4a9a"
+const FUZZJSON_NINF = "hypofuzz-ninf-a928fa52b3ea4a9a"
+const FUZZJSON_NAN = "hypofuzz-nan-a928fa52b3ea4a9a"
 
 export function fuzzjsonReviver(_key: string, value: any): any {
   if (value === FUZZJSON_INF) return Infinity

--- a/src/hypofuzz/frontend/src/utils/fuzzjson.ts
+++ b/src/hypofuzz/frontend/src/utils/fuzzjson.ts
@@ -1,7 +1,7 @@
 // must match python's hypofuzz.utils
-const FUZZJSON_INF = "hypofuzz-inf-a928fa52b3ea4a9a"
-const FUZZJSON_NINF = "hypofuzz-ninf-a928fa52b3ea4a9a"
-const FUZZJSON_NAN = "hypofuzz-nan-a928fa52b3ea4a9a"
+const FUZZJSON_INF = "hypofuzz-inf-a928fa52"
+const FUZZJSON_NINF = "hypofuzz-ninf-a928fa52"
+const FUZZJSON_NAN = "hypofuzz-nan-a928fa52"
 
 export function fuzzjsonReviver(_key: string, value: any): any {
   if (value === FUZZJSON_INF) return Infinity

--- a/src/hypofuzz/frontend/src/utils/utils.ts
+++ b/src/hypofuzz/frontend/src/utils/utils.ts
@@ -200,3 +200,33 @@ export function navigateOnClick(
 export function readableNodeid(nodeid: string): string {
   return nodeid.split("::").pop() || nodeid
 }
+
+export function commonPrefix(strings: string[], delimiter: string = "/"): string {
+  if (!strings || strings.length < 2) {
+    return ""
+  }
+
+  const segments = strings.map(s => s.split(delimiter))
+  const minLen = Math.min(...segments.map(s => s.length))
+
+  const prefix: string[] = []
+  for (let i = 0; i < minLen; i++) {
+    const seg = segments[0][i]
+    const allMatch = segments.every(parts => parts[i] === seg)
+    if (!allMatch) {
+      break
+    }
+    prefix.push(seg)
+  }
+
+  if (prefix.length === 0) {
+    return ""
+  }
+
+  const joined = prefix.join(delimiter)
+  const withDelim = joined ? joined + delimiter : ""
+  if (withDelim && strings.every(s => s.startsWith(withDelim))) {
+    return withDelim
+  }
+  return ""
+}

--- a/src/hypofuzz/frontend/tests/utils.test.ts
+++ b/src/hypofuzz/frontend/tests/utils.test.ts
@@ -1,5 +1,6 @@
 import { test, assert } from "vitest"
 import { formatNumber } from "../src/utils/testStats"
+import { commonPrefix } from "../src/utils/utils"
 
 const cases: Array<[number, string]> = [
   [0, "0"],
@@ -14,5 +15,20 @@ const cases: Array<[number, string]> = [
 for (const [input, expected] of cases) {
   test(`formatNumber(${input})`, function () {
     assert.equal(formatNumber(input), expected)
+  })
+}
+
+const prefixCases: Array<[string[], string]> = [
+  [["tests/common/a", "tests/common/b"], "tests/common/"],
+  [["alpha/beta/gamma", "alpha/beta/delta", "alpha/beta/epsilon"], "alpha/beta/"],
+  [["no/shared", "prefix/here"], ""],
+  [["tests/common", "tests/common/foo"], ""],
+  [["a/b"], ""],
+  [[], ""],
+]
+
+for (const [inputs, expected] of prefixCases) {
+  test(`commonPrefix(${JSON.stringify(inputs)})`, function () {
+    assert.equal(commonPrefix(inputs), expected)
   })
 }

--- a/src/hypofuzz/hypofuzz.py
+++ b/src/hypofuzz/hypofuzz.py
@@ -12,7 +12,7 @@ import time
 import traceback
 from collections import defaultdict
 from collections.abc import Callable, Mapping, Sequence
-from contextlib import nullcontext
+from contextlib import nullcontext, redirect_stdout
 from functools import cache, partial
 from multiprocessing import Manager, Process
 from pathlib import Path
@@ -418,6 +418,9 @@ class FuzzTarget:
                 if self.pytest_item is not None
                 else nullcontext()
             ),
+            # silence stdout from tests
+            open(os.devnull, "w") as null,
+            redirect_stdout(null),
         ):
             try:
                 self.state._execute_once_for_engine(data)

--- a/src/hypofuzz/utils.py
+++ b/src/hypofuzz/utils.py
@@ -12,9 +12,9 @@ T = TypeVar("T")
 
 process_uuid = uuid4().hex
 
-FUZZJSON_INF = "hypofuzz-inf-a928fa52b3ea4a9a9af36ccef7c6cf93"
-FUZZJSON_NINF = "hypofuzz-ninf-a928fa52b3ea4a9a9af36ccef7c6cf93"
-FUZZJSON_NAN = "hypofuzz-nan-a928fa52b3ea4a9a9af36ccef7c6cf93"
+FUZZJSON_INF = "hypofuzz-inf-a928fa52b3ea4a9a"
+FUZZJSON_NINF = "hypofuzz-ninf-a928fa52b3ea4a9a"
+FUZZJSON_NAN = "hypofuzz-nan-a928fa52b3ea4a9a"
 
 
 def convert_to_fuzzjson(value: Any) -> Any:

--- a/src/hypofuzz/utils.py
+++ b/src/hypofuzz/utils.py
@@ -12,9 +12,9 @@ T = TypeVar("T")
 
 process_uuid = uuid4().hex
 
-FUZZJSON_INF = "hypofuzz-inf-a928fa52b3ea4a9a"
-FUZZJSON_NINF = "hypofuzz-ninf-a928fa52b3ea4a9a"
-FUZZJSON_NAN = "hypofuzz-nan-a928fa52b3ea4a9a"
+FUZZJSON_INF = "hypofuzz-inf-a928fa52"
+FUZZJSON_NINF = "hypofuzz-ninf-a928fa52"
+FUZZJSON_NAN = "hypofuzz-nan-a928fa52"
 
 
 def convert_to_fuzzjson(value: Any) -> Any:


### PR DESCRIPTION
fuzzjson inf/nan values are now stored at the observation/database/model level, since iterating over all observations when serializing gets expensive quickly.