### PR TITLE
dashboard: guard stability ratio when every observation is UNKNOWN

### DIFF
--- a/src/hypofuzz/dashboard/test.py
+++ b/src/hypofuzz/dashboard/test.py
@@ -228,7 +228,15 @@ class Test:
             for observation in self.rolling_observations
         )
 
-        return count_stable / (count_stable + count_unstable)
+        # Every observation has UNKNOWN stability (the remaining Stability
+        # variant), so there is no signal to compute a ratio from. Returning
+        # a 0/0 ZeroDivisionError here used to tear down the dashboard
+        # websocket every time the UI polled (#245).
+        total = count_stable + count_unstable
+        if total == 0:
+            return None
+
+        return count_stable / total
 
     @property
     def phase(self) -> Phase | None:


### PR DESCRIPTION
### Problem

`Test.stability` only treats the "no rolling observations" case specially:

```python
@property
def stability(self) -> float | None:
    if not self.rolling_observations:
        return None

    count_stable   = sum(o.stability is Stability.STABLE   for o in self.rolling_observations)
    count_unstable = sum(o.stability is Stability.UNSTABLE for o in self.rolling_observations)

    return count_stable / (count_stable + count_unstable)
```

If every rolling observation records `Stability.UNKNOWN` (the third
variant) — which happens routinely while a test is still being
collected — both counts are 0 and the division raises
`ZeroDivisionError`. The stack in #245 has it bubbling up through
`websocket.send_tests`, so every subsequent poll re-triggers the
exception and the dashboard websocket stays broken.

### Fix

Compute the denominator explicitly, return `None` when it is 0, and
keep the existing ratio otherwise.

```diff
- return count_stable / (count_stable + count_unstable)
+ total = count_stable + count_unstable
+ if total == 0:
+     return None
+ return count_stable / total
```

No behaviour change for any test that has at least one stable or
unstable observation — they continue to return the same float as
before.

Fixes #245
