### PR TITLE
Fix worker shutdown to prevent crashes when Manager tears down

### DIFF
--- a/src/hypofuzz/hypofuzz.py
+++ b/src/hypofuzz/hypofuzz.py
@@ -607,7 +607,12 @@ class FuzzWorker:
         self.db.worker_identities.save(self.worker_identity)
 
         while True:
-            self._update_targets(self.shared_state["hub_state"]["nodeids"])
+            hub_state = self.shared_state["hub_state"]
+            if hub_state.get("shutdown", False):
+                # hub has signalled that we should exit, before it tears down
+                # the Manager (issue #246).
+                break
+            self._update_targets(hub_state["nodeids"])
 
             # it's possible to go through an interim period where we have no nodeids,
             # but the hub still has nodeids to assign. We don't want the worker to
@@ -699,6 +704,10 @@ class FuzzWorker:
 
 
 class FuzzWorkerHub:
+    # how often the hub wakes up to rebalance work across workers and to
+    # check whether every worker has run out of things to fuzz.
+    _rebalance_interval: float = 60.0
+
     def __init__(
         self,
         *,
@@ -711,14 +720,14 @@ class FuzzWorkerHub:
         self.n_processes = n_processes
 
         self.shared_states: list[Mapping] = []
+        self.processes: list[Process] = []
 
     def start(self) -> None:
-        processes: list[Process] = []
-
         with Manager() as manager:
             for _ in range(self.n_processes):
                 shared_state = manager.dict()
                 shared_state["hub_state"] = manager.dict()
+                shared_state["hub_state"]["shutdown"] = False
                 shared_state["worker_state"] = manager.dict()
                 shared_state["worker_state"]["nodeids"] = manager.dict()
                 shared_state["worker_state"]["current_lifetime"] = 0.0
@@ -732,30 +741,54 @@ class FuzzWorkerHub:
                         "shared_state": shared_state,
                     },
                 )
-                processes.append(process)
+                self.processes.append(process)
                 self.shared_states.append(shared_state)
 
             # rebalance once at the start to put the initial node assignments
             # in the shared state
             self._rebalance()
-            for process in processes:
+            for process in self.processes:
                 process.start()
 
-            while True:
-                # rebalance automatically on an interval.
-                # We may want to check some condition more frequently than this,
-                # like "a process has no more nodes" (due to e.g. finding a
-                # failure). So we rebalance either once every n seconds, or whenever
-                # some worker needs a rebalancing.
-                time.sleep(60)
-                # if none of our workers have anything to do, we should exit as well
-                if all(
-                    not state["worker_state"]["valid_nodeids"]
-                    for state in self.shared_states
-                ):
-                    break
+            try:
+                while True:
+                    # rebalance automatically on an interval.
+                    # We may want to check some condition more frequently than this,
+                    # like "a process has no more nodes" (due to e.g. finding a
+                    # failure). So we rebalance either once every n seconds, or whenever
+                    # some worker needs a rebalancing.
+                    time.sleep(self._rebalance_interval)
+                    # if none of our workers have anything to do, we should exit as well
+                    if all(
+                        not state["worker_state"]["valid_nodeids"]
+                        for state in self.shared_states
+                    ):
+                        break
 
-                self._rebalance()
+                    self._rebalance()
+            finally:
+                # Tell workers to exit, and wait for them to stop touching the
+                # shared state before we leave this `with Manager()` block.
+                # Otherwise they crash with BrokenPipeError / FileNotFoundError
+                # when the Manager tears down its IPC sockets (issue #246).
+                self._shutdown_workers()
+
+    def _shutdown_workers(self) -> None:
+        for state in self.shared_states:
+            try:
+                state["hub_state"]["shutdown"] = True
+            except Exception:
+                # the Manager may already be unreachable (e.g. if we got here
+                # via an unexpected exception); fall through to terminate.
+                pass
+        for process in self.processes:
+            process.join(timeout=5)
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=2)
+            if process.is_alive():
+                process.kill()
+                process.join()
 
     def _rebalance(self) -> None:
         # rebalance the assignment of nodeids to workers, according to the

--- a/src/hypofuzz/hypofuzz.py
+++ b/src/hypofuzz/hypofuzz.py
@@ -606,13 +606,11 @@ class FuzzWorker:
         self.db.worker_uuids.save(process_uuid.encode("ascii"))
         self.db.worker_identities.save(self.worker_identity)
 
-        while True:
-            hub_state = self.shared_state["hub_state"]
-            if hub_state.get("shutdown", False):
-                # hub has signalled that we should exit, before it tears down
-                # the Manager (issue #246).
-                break
-            self._update_targets(hub_state["nodeids"])
+        # `shutdown` is set by the hub when it's about to tear down the Manager;
+        # without breaking out here workers crash on the next shared_state access
+        # (issue #246).
+        while not self.shared_state["hub_state"].get("shutdown", False):
+            self._update_targets(self.shared_state["hub_state"]["nodeids"])
 
             # it's possible to go through an interim period where we have no nodeids,
             # but the hub still has nodeids to assign. We don't want the worker to
@@ -750,22 +748,20 @@ class FuzzWorkerHub:
             for process in self.processes:
                 process.start()
 
+            # rebalance automatically on an interval.
+            # We may want to check some condition more frequently than this,
+            # like "a process has no more nodes" (due to e.g. finding a
+            # failure). So we rebalance either once every n seconds, or whenever
+            # some worker needs a rebalancing.
+            # Exit once no worker has anything left to do.
             try:
-                while True:
-                    # rebalance automatically on an interval.
-                    # We may want to check some condition more frequently than this,
-                    # like "a process has no more nodes" (due to e.g. finding a
-                    # failure). So we rebalance either once every n seconds, or whenever
-                    # some worker needs a rebalancing.
-                    time.sleep(self._rebalance_interval)
-                    # if none of our workers have anything to do, we should exit as well
-                    if all(
-                        not state["worker_state"]["valid_nodeids"]
-                        for state in self.shared_states
-                    ):
-                        break
-
+                time.sleep(self._rebalance_interval)
+                while any(
+                    state["worker_state"]["valid_nodeids"]
+                    for state in self.shared_states
+                ):
                     self._rebalance()
+                    time.sleep(self._rebalance_interval)
             finally:
                 # Tell workers to exit, and wait for them to stop touching the
                 # shared state before we leave this `with Manager()` block.
@@ -781,14 +777,23 @@ class FuzzWorkerHub:
                 # the Manager may already be unreachable (e.g. if we got here
                 # via an unexpected exception); fall through to terminate.
                 pass
-        for process in self.processes:
-            process.join(timeout=5)
-            if process.is_alive():
-                process.terminate()
-                process.join(timeout=2)
-            if process.is_alive():
-                process.kill()
-                process.join()
+
+        def _join_all(processes: list[Process], timeout: float) -> list[Process]:
+            # join() all processes within a single shared deadline, so one slow
+            # worker doesn't make us wait N * timeout in the worst case.
+            deadline = time.monotonic() + timeout
+            for process in processes:
+                process.join(timeout=max(0.0, deadline - time.monotonic()))
+            return [p for p in processes if p.is_alive()]
+
+        still_alive = _join_all(self.processes, timeout=5)
+        for process in still_alive:
+            process.terminate()
+        still_alive = _join_all(still_alive, timeout=2)
+        for process in still_alive:
+            process.kill()
+        for process in still_alive:
+            process.join()
 
     def _rebalance(self) -> None:
         # rebalance the assignment of nodeids to workers, according to the

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -5,7 +5,7 @@ from common import setup_test_code, wait_for
 from hypothesis.database import DirectoryBasedExampleDatabase
 
 from hypofuzz.database import HypofuzzDatabase
-from hypofuzz.hypofuzz import _start_worker
+from hypofuzz.hypofuzz import FuzzWorkerHub, _start_worker
 
 test_code = """
 @given(st.integers())
@@ -56,6 +56,34 @@ def test_workers(tmp_path):
 
         process.kill()
         process.join()
+
+
+def test_hub_shuts_down_workers_cleanly(tmp_path):
+    # Regression test for #246: when the hub finishes a full exploration pass
+    # (here, triggered by an always-failing test), it must signal workers to
+    # exit before tearing down the Manager. Otherwise workers crash with
+    # BrokenPipeError / FileNotFoundError on their next shared_state access.
+    code = """
+@given(st.integers())
+def test_always_fails(n):
+    assert False
+"""
+    test_dir, _db_dir = setup_test_code(tmp_path, code)
+
+    hub = FuzzWorkerHub(
+        nodeids=["test_a.py::test_always_fails"],
+        pytest_args=[str(test_dir)],
+        n_processes=1,
+    )
+    hub._rebalance_interval = 0.5
+    hub.start()
+
+    assert hub.processes
+    for process in hub.processes:
+        assert process.exitcode == 0, (
+            f"worker exited with code {process.exitcode} (likely crashed on "
+            f"shared_state access after Manager shutdown)"
+        )
 
 
 def test_worker_writes_worker_identity(tmp_path):


### PR DESCRIPTION
## Summary
This PR fixes #246 where worker processes would crash with `BrokenPipeError` or `FileNotFoundError` when the hub's `Manager` tore down its IPC sockets. The fix ensures workers are signaled to exit and have stopped accessing shared state before the Manager is destroyed.

## Key Changes
- **Worker shutdown signaling**: Added a `shutdown` flag in `hub_state` that the hub sets to signal workers to exit gracefully
- **Worker loop exit condition**: Modified `FuzzWorker.start()` to check the shutdown flag and break from its main loop before attempting further shared state access
- **Hub shutdown sequence**: Implemented `_shutdown_workers()` method that:
  - Sets the shutdown flag for all workers
  - Waits for processes to join with a 5-second timeout
  - Falls back to `terminate()` and `kill()` if processes don't exit cleanly
  - Handles exceptions gracefully in case the Manager is already unreachable
- **Hub state management**: Moved `processes` list to instance variable to enable proper cleanup in the finally block
- **Rebalance interval**: Extracted the 60-second rebalance interval as a class variable for easier testing
- **Test coverage**: Added regression test `test_hub_shuts_down_workers_cleanly()` that verifies workers exit cleanly (exitcode 0) when the hub completes exploration

## Implementation Details
- The shutdown sequence is wrapped in a try-finally block to ensure `_shutdown_workers()` is called even if an exception occurs during the main hub loop
- Worker processes check the shutdown flag at the start of each iteration before accessing shared state
- The shutdown method includes exception handling for cases where the Manager may already be unreachable
- Progressive termination strategy: join → terminate → kill to handle various process states

https://claude.ai/code/session_014Pd4CKvrcSqXefNdRjaFXn