### PR TITLE
Fix linearization desync when reports arrive out-of-order

### DIFF
--- a/src/hypofuzz/dashboard/test.py
+++ b/src/hypofuzz/dashboard/test.py
@@ -92,9 +92,9 @@ class Test:
         # this function is pretty expensive. Only call it at important junctures,
         # or in tests
         linear_keys = [self._linear_sort_key(r) for r in self.linear_reports]
-        assert all(k1 <= k2 for k1, k2 in zip(linear_keys, linear_keys[1:])), (
-            linear_keys
-        )
+        assert all(
+            k1 <= k2 for k1, k2 in zip(linear_keys, linear_keys[1:])
+        ), linear_keys
 
         linear_status_counts = self.linear_status_counts()
         assert all(
@@ -205,9 +205,7 @@ class Test:
         predecessor = linear_report
         for j in range(reports_index + 1, len(worker_reports)):
             stale = worker_reports[j]
-            fresh = ReportWithDiff.from_reports(
-                stale, last_worker_report=predecessor
-            )
+            fresh = ReportWithDiff.from_reports(stale, last_worker_report=predecessor)
             worker_reports[j] = fresh
 
             # timestamp_monotonic can only have increased, so the report may

--- a/src/hypofuzz/dashboard/test.py
+++ b/src/hypofuzz/dashboard/test.py
@@ -70,6 +70,15 @@ class Test:
         return convert_db_key(self.database_key, to="bytes")
 
     @staticmethod
+    def _linear_sort_key(r: ReportWithDiff) -> tuple[float, str]:
+        # Ordering linear_reports solely by timestamp_monotonic is not a total
+        # order: two reports from different workers can easily collide. Without
+        # a tiebreaker the position of such reports depended on insertion order,
+        # which made add_report non-commutative and allowed the linearization to
+        # desync from itself after out-of-order inserts.
+        return (r.timestamp_monotonic, r.worker_uuid)
+
+    @staticmethod
     def _assert_reports_ordered(
         reports: list[ReportWithDiff], attributes: list[str]
     ) -> None:
@@ -82,7 +91,10 @@ class Test:
     def _check_invariants(self) -> None:
         # this function is pretty expensive. Only call it at important junctures,
         # or in tests
-        self._assert_reports_ordered(self.linear_reports, ["timestamp_monotonic"])
+        linear_keys = [self._linear_sort_key(r) for r in self.linear_reports]
+        assert all(k1 <= k2 for k1, k2 in zip(linear_keys, linear_keys[1:])), (
+            linear_keys
+        )
 
         linear_status_counts = self.linear_status_counts()
         assert all(
@@ -109,7 +121,8 @@ class Test:
                 {r.database_key for r in reports},
             )
             assert {r.worker_uuid for r in reports} == {worker_uuid}
-            self._assert_reports_ordered(self.linear_reports, ["timestamp_monotonic"])
+            # within a single worker, reports are sorted by elapsed_time
+            self._assert_reports_ordered(reports, ["elapsed_time", "status_counts"])
 
         # this is not always true due to floating point error accumulation.
         # total_elapsed_time = 0.0
@@ -163,53 +176,62 @@ class Test:
         # to convey the time spent searching for bugs. But we should be careful
         # when measuring cost to compute a separate "overhead" statistic which
         # takes every input and elapsed_time into account regardless of phase.
-        if linear_report.phase is not Phase.REPLAY or (
+        included_in_linear = linear_report.phase is not Phase.REPLAY or (
             linear_report.behaviors >= self.behaviors
             and linear_report.fingerprints >= self.fingerprints
-        ):
+        )
+        if included_in_linear:
             # insert in-order, maintaining the sorted invariant
             index = fast_bisect_right(
                 self.linear_reports,
-                linear_report.timestamp_monotonic,
-                key=lambda r: r.timestamp_monotonic,
+                self._linear_sort_key(linear_report),
+                key=self._linear_sort_key,
             )
             self.linear_reports.insert(index, linear_report)
-            if index != len(self.linear_reports) - 1:
-                # if we didn't just append this report to the end, we need to:
-                # * recompute the diff for the next report from this worker (if
-                #   there is one)
-                # * invalidate cumsum caches for the indices after `index`
-                next_worker_report = None
-                for i_offset, report_candidate in enumerate(
-                    self.linear_reports[index + 1 :]
-                ):
-                    if linear_report.worker_uuid == report_candidate.worker_uuid:
-                        next_worker_report = report_candidate
-                        break
+            appended_at_end = index == len(self.linear_reports) - 1
+        else:
+            appended_at_end = False
 
-                # note that there need not be another report from this worker
-                # after this report, if this was the first report to arrive from
-                # the worker, and it arrived out of order wrt timestamp_monotonic
-                # for the existing linear_reports.
-                if next_worker_report is not None:
-                    assert (
-                        self.linear_reports[index + 1 + i_offset] == next_worker_report
-                    )
-                    next_worker_report = ReportWithDiff.from_reports(
-                        next_worker_report,
-                        last_worker_report=linear_report,
-                    )
-                    self.linear_reports[index + 1 + i_offset] = next_worker_report
+        # If this report is not the last one for its worker, the subsequent
+        # reports' diffs were computed against the wrong predecessor. Recompute
+        # them in order, updating both reports_by_worker and linear_reports.
+        #
+        # We iterate reports_by_worker (sorted by elapsed_time) rather than
+        # linear_reports (sorted by timestamp_monotonic); the two orderings can
+        # diverge, and elapsed_time is what ReportWithDiff.from_reports uses
+        # to compute diffs.
+        worker_reports = self.reports_by_worker[report.worker_uuid]
+        any_recomputed = reports_index + 1 < len(worker_reports)
+        predecessor = linear_report
+        for j in range(reports_index + 1, len(worker_reports)):
+            stale = worker_reports[j]
+            fresh = ReportWithDiff.from_reports(
+                stale, last_worker_report=predecessor
+            )
+            worker_reports[j] = fresh
 
-                # now invalidate the cumsum caches for any indices after `index`
-                caches: list[LRUCache] = [
-                    self._status_counts_cumsum,
-                    self._elapsed_time_cumsum,
-                ]
-                for cache in caches:
-                    for key, (start_idx, values) in cache.cache.items():
-                        if index >= start_idx:
-                            cache[key] = (start_idx, values[: index - start_idx])
+            # timestamp_monotonic can only have increased, so the report may
+            # need to move later in linear_reports. Pop-and-reinsert rather
+            # than updating in place to preserve the sort invariant. Some
+            # reports (filtered-out REPLAYs) are not in linear_reports, so
+            # skip those silently.
+            for i, lr in enumerate(self.linear_reports):
+                if lr is stale:
+                    del self.linear_reports[i]
+                    new_index = fast_bisect_right(
+                        self.linear_reports,
+                        self._linear_sort_key(fresh),
+                        key=self._linear_sort_key,
+                    )
+                    self.linear_reports.insert(new_index, fresh)
+                    break
+            predecessor = fresh
+
+        # The cumsum caches assume linear_reports only grows at the end. Any
+        # middle insert or recompute of existing reports invalidates them.
+        if not appended_at_end or any_recomputed:
+            self._status_counts_cumsum = LRUCache(16)
+            self._elapsed_time_cumsum = LRUCache(16)
 
     @property
     def stability(self) -> float | None:

--- a/tests/test_linearize.py
+++ b/tests/test_linearize.py
@@ -398,9 +398,7 @@ def test_all_subsequent_worker_reports_are_recomputed():
 
     # insert out-of-order between the first and second existing reports
     test.add_report(
-        report_inline(
-            elapsed_time=2.0, timestamp=101, status_counts=_counts(valid=20)
-        )
+        report_inline(elapsed_time=2.0, timestamp=101, status_counts=_counts(valid=20))
     )
 
     reports = test.reports_by_worker["inline-worker_uuid"]
@@ -426,19 +424,25 @@ def test_recompute_uses_reports_by_worker_not_linear_reports():
     # worker_2: elapsed=2 @ timestamp 100 (sits BEFORE worker_1 in linear_reports)
     test.add_report(
         report_inline(
-            elapsed_time=1.0, timestamp=200, worker_uuid="worker_1",
+            elapsed_time=1.0,
+            timestamp=200,
+            worker_uuid="worker_1",
             status_counts=_counts(valid=10),
         )
     )
     test.add_report(
         report_inline(
-            elapsed_time=3.0, timestamp=201, worker_uuid="worker_1",
+            elapsed_time=3.0,
+            timestamp=201,
+            worker_uuid="worker_1",
             status_counts=_counts(valid=30),
         )
     )
     test.add_report(
         report_inline(
-            elapsed_time=2.0, timestamp=100, worker_uuid="worker_2",
+            elapsed_time=2.0,
+            timestamp=100,
+            worker_uuid="worker_2",
             status_counts=_counts(valid=20),
         )
     )
@@ -449,7 +453,9 @@ def test_recompute_uses_reports_by_worker_not_linear_reports():
     # worker_2's report as the next one from worker_1 and fail to recompute.
     test.add_report(
         report_inline(
-            elapsed_time=2.0, timestamp=200.5, worker_uuid="worker_1",
+            elapsed_time=2.0,
+            timestamp=200.5,
+            worker_uuid="worker_1",
             status_counts=_counts(valid=15),
         )
     )
@@ -457,7 +463,7 @@ def test_recompute_uses_reports_by_worker_not_linear_reports():
     worker_1_reports = test.reports_by_worker["worker_1"]
     assert [r.status_counts_diff for r in worker_1_reports] == [
         _counts(valid=10),  # 10 - 0
-        _counts(valid=5),   # 15 - 10
+        _counts(valid=5),  # 15 - 10
         _counts(valid=15),  # 30 - 15
     ]
     test._check_invariants()

--- a/tests/test_linearize.py
+++ b/tests/test_linearize.py
@@ -107,6 +107,12 @@ def reports(
                 st.floats(0, 1_000_000),
                 min_size=len(ninputs),
                 max_size=len(ninputs),
+                # strictly increasing: reports from the same worker always advance
+                # elapsed_time by a nonzero amount. Ties in the strategy would
+                # generate unrealistic reports with equal elapsed_time but
+                # different status_counts, which the linearization logic (and
+                # reality) is not designed to handle.
+                unique=True,
             ).map(sorted)
         )
         for ninput, timestamp, elapsed_time in zip(ninputs, timestamps, elapsed_times):
@@ -330,3 +336,186 @@ def test_desynced_timestamp():
 
     assert test.linear_elapsed_time() == [1.0, 2.0, 3.0, 7.0]
     test._check_invariants()
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for #244: AssertionError from stale or unsynced linearization
+# state when reports arrive across workers with overlapping elapsed_times.
+# ---------------------------------------------------------------------------
+
+
+def _counts(
+    *, interesting: int = 0, valid: int = 0, invalid: int = 0, overrun: int = 0
+) -> StatusCounts:
+    return StatusCounts(
+        {
+            Status.INTERESTING: interesting,
+            Status.VALID: valid,
+            Status.INVALID: invalid,
+            Status.OVERRUN: overrun,
+        }
+    )
+
+
+def test_cache_invalidated_on_middle_insert_from_new_worker():
+    # Previously, the cumsum cache was only invalidated if the new report was
+    # inserted in the middle of linear_reports AND there was already a later
+    # report from the same worker. A new worker's first report landing in the
+    # middle fell through the crack and left the cache stale.
+    test = _test_for_reports(
+        [], database_key=b"inline-database_key", nodeid="inline-nodeid"
+    )
+
+    test.add_report(
+        report_inline(elapsed_time=1.0, timestamp=101, worker_uuid="worker_1")
+    )
+    test.add_report(
+        report_inline(elapsed_time=5.0, timestamp=105, worker_uuid="worker_1")
+    )
+    # populate the cache
+    assert test.linear_elapsed_time() == [1.0, 5.0]
+
+    # worker_2's first-ever report lands between the two worker_1 entries
+    test.add_report(
+        report_inline(elapsed_time=1.0, timestamp=102, worker_uuid="worker_2")
+    )
+    assert test.linear_elapsed_time() == [1.0, 2.0, 6.0]
+    test._check_invariants()
+
+
+def test_all_subsequent_worker_reports_are_recomputed():
+    # Previously only the immediately-next report from the worker was rebuilt
+    # against the out-of-order insert, leaving the tail with stale diffs.
+    test = _test_for_reports(
+        [], database_key=b"inline-database_key", nodeid="inline-nodeid"
+    )
+    for elapsed, ts, valid in [(1.0, 100, 10), (3.0, 102, 30), (4.0, 103, 40)]:
+        test.add_report(
+            report_inline(
+                elapsed_time=elapsed, timestamp=ts, status_counts=_counts(valid=valid)
+            )
+        )
+
+    # insert out-of-order between the first and second existing reports
+    test.add_report(
+        report_inline(
+            elapsed_time=2.0, timestamp=101, status_counts=_counts(valid=20)
+        )
+    )
+
+    reports = test.reports_by_worker["inline-worker_uuid"]
+    assert [r.status_counts_diff for r in reports] == [
+        _counts(valid=10),
+        _counts(valid=10),
+        _counts(valid=10),
+        _counts(valid=10),
+    ]
+    test._check_invariants()
+
+
+def test_recompute_uses_reports_by_worker_not_linear_reports():
+    # linear_reports is sorted by timestamp_monotonic; reports_by_worker is
+    # sorted by elapsed_time. When finding the next report from a worker to
+    # recompute, the search must use reports_by_worker - the two orderings
+    # diverge when timestamps and elapsed_times aren't aligned across workers.
+    test = _test_for_reports(
+        [], database_key=b"inline-database_key", nodeid="inline-nodeid"
+    )
+
+    # worker_1: elapsed=1 @ timestamp 200, elapsed=3 @ timestamp 201
+    # worker_2: elapsed=2 @ timestamp 100 (sits BEFORE worker_1 in linear_reports)
+    test.add_report(
+        report_inline(
+            elapsed_time=1.0, timestamp=200, worker_uuid="worker_1",
+            status_counts=_counts(valid=10),
+        )
+    )
+    test.add_report(
+        report_inline(
+            elapsed_time=3.0, timestamp=201, worker_uuid="worker_1",
+            status_counts=_counts(valid=30),
+        )
+    )
+    test.add_report(
+        report_inline(
+            elapsed_time=2.0, timestamp=100, worker_uuid="worker_2",
+            status_counts=_counts(valid=20),
+        )
+    )
+
+    # Now insert a worker_1 report at elapsed=2 (between its existing two).
+    # The "next" worker_1 report (elapsed=3) comes AFTER worker_2's report in
+    # linear_reports; the old search in linear_reports could incorrectly treat
+    # worker_2's report as the next one from worker_1 and fail to recompute.
+    test.add_report(
+        report_inline(
+            elapsed_time=2.0, timestamp=200.5, worker_uuid="worker_1",
+            status_counts=_counts(valid=15),
+        )
+    )
+
+    worker_1_reports = test.reports_by_worker["worker_1"]
+    assert [r.status_counts_diff for r in worker_1_reports] == [
+        _counts(valid=10),  # 10 - 0
+        _counts(valid=5),   # 15 - 10
+        _counts(valid=15),  # 30 - 15
+    ]
+    test._check_invariants()
+
+
+def test_deterministic_tiebreaker_for_equal_timestamp_monotonic():
+    # Two workers submitting reports that land at the same timestamp_monotonic
+    # must sort deterministically, so add_report is commutative.
+    test_a = _test_for_reports(
+        [], database_key=b"inline-database_key", nodeid="inline-nodeid"
+    )
+    test_b = _test_for_reports(
+        [], database_key=b"inline-database_key", nodeid="inline-nodeid"
+    )
+    reports = [
+        report_inline(elapsed_time=1.0, timestamp=100, worker_uuid="worker_a"),
+        report_inline(elapsed_time=1.0, timestamp=100, worker_uuid="worker_b"),
+    ]
+    test_a.add_report(reports[0])
+    test_a.add_report(reports[1])
+    test_b.add_report(reports[1])
+    test_b.add_report(reports[0])
+
+    assert [r.worker_uuid for r in test_a.linear_reports] == [
+        r.worker_uuid for r in test_b.linear_reports
+    ]
+    test_a._check_invariants()
+    test_b._check_invariants()
+
+
+@given(st.data())
+@settings(suppress_health_check=[HealthCheck.too_slow], report_multiple_bugs=False)
+def test_add_report_is_permutation_invariant(data):
+    # The heart of #244: no matter what order a set of reports arrives in,
+    # the linearization should produce the same result. Excluding REPLAY is
+    # deliberate - its inclusion in linear_reports depends on the running
+    # max behaviors/fingerprints and so is intentionally order-dependent.
+    reports_ = data.draw(reports())
+    assume(len(reports_) > 1)
+    reports_ = [r for r in reports_ if r.phase is not Phase.REPLAY]
+    assume(len(reports_) > 1)
+
+    permutation = data.draw(st.permutations(reports_))
+
+    test1 = _test_for_reports(
+        [], database_key=reports_[0].database_key, nodeid=reports_[0].nodeid
+    )
+    for report in reports_:
+        test1.add_report(report)
+
+    test2 = _test_for_reports(
+        [], database_key=reports_[0].database_key, nodeid=reports_[0].nodeid
+    )
+    for report in permutation:
+        test2.add_report(report)
+
+    assert test1.linear_status_counts() == test2.linear_status_counts()
+    assert test1.linear_elapsed_time() == pytest.approx(test2.linear_elapsed_time())
+    assert_reports_almost_equal(test1.linear_reports, test2.linear_reports)
+    test1._check_invariants()
+    test2._check_invariants()


### PR DESCRIPTION
## Summary
Fixes #244 where the linearization logic could enter an inconsistent state when reports from multiple workers arrived with overlapping elapsed times. The core problem was that the cumsum cache invalidation and diff recomputation logic didn't handle all cases of out-of-order inserts correctly.

## Key Changes

- **Deterministic sorting for linear_reports**: Added a tiebreaker (`worker_uuid`) to the sort key for `linear_reports` so that reports with equal `timestamp_monotonic` sort deterministically. This makes `add_report` commutative and prevents insertion-order dependencies.

- **Complete diff recomputation**: When a report is inserted in the middle of a worker's sequence, all subsequent reports from that worker are now recomputed (not just the immediately-next one). This ensures diffs remain correct throughout the entire tail.

- **Correct predecessor tracking**: Fixed the logic to use `reports_by_worker` (sorted by elapsed_time) rather than `linear_reports` (sorted by timestamp_monotonic) when finding the next report to recompute. These orderings can diverge when timestamps and elapsed times aren't aligned across workers.

- **Proper cache invalidation**: Simplified cache invalidation to clear both cumsum caches whenever a report is inserted in the middle or any existing reports are recomputed, rather than trying to surgically update cache entries.

- **Enhanced test coverage**: Added comprehensive regression tests including:
  - Cache invalidation for new workers' first reports landing in the middle
  - Recomputation of all subsequent worker reports
  - Correct handling of divergent timestamp/elapsed_time orderings across workers
  - Deterministic tiebreaker behavior
  - Property-based test verifying permutation invariance of linearization results

- **Stricter test data generation**: Updated the `reports()` strategy to generate strictly increasing elapsed times within each worker to avoid generating unrealistic test cases with equal elapsed times but different status counts.

## Implementation Details

The fix ensures that the linearization state remains consistent regardless of the order in which reports arrive. The key insight is that when an out-of-order report is inserted, all subsequent reports from the same worker must be recomputed because their diffs depend on the correct predecessor. By iterating through `reports_by_worker` (which is sorted by elapsed_time, the actual ordering used in diff computation) rather than `linear_reports`, we correctly identify which reports need recomputation even when the two orderings diverge.

https://claude.ai/code/session_01G9fi5ppURo3AUcdPbz7dEm